### PR TITLE
HIP_ACO successor list refactor

### DIFF
--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -181,9 +181,9 @@ protected:
 
   bool includesUnpipelined_;
 
-  __host__ __device__
+  __host__
   InstCount CmputRsrcLwrBound_();
-  __host__ __device__
+  __host__
   virtual InstCount CmputAbslutUprBound_();
 };
 
@@ -465,19 +465,19 @@ protected:
 
   FUNC_RESULT Finish_();
 
-  __host__ __device__
+  __host__
   void CmputCrtclPaths_();
-  __host__ __device__
+  __host__
   void CmputCrtclPathsFrmRoot_();
-  __host__ __device__
+  __host__
   void CmputCrtclPathsFrmLeaf_();
-  __host__ __device__
+  __host__
   void CmputCrtclPathsFrmRcrsvScsr_(SchedInstruction *ref);
-  __host__ __device__
+  __host__
   void CmputCrtclPathsFrmRcrsvPrdcsr_(SchedInstruction *ref);
-  __host__ __device__
+  __host__
   void CmputRltvCrtclPaths_(DIRECTION dir);
-  __host__ __device__
+  __host__
   void CmputBasicLwrBounds_();
 
   void WriteNodeInfoToF2File_(FILE *file);

--- a/include/opt-sched/Scheduler/graph.h
+++ b/include/opt-sched/Scheduler/graph.h
@@ -64,7 +64,7 @@ struct GraphEdge {
 
   // Returns the node on the other side of the edge from the provided node.
   // Assumes that the argument is one of the nodes on the sides of the edge.
-  __host__ __device__
+  __host__
   UDT_GNODES GetOtherNodeNum(UDT_GNODES nodeNum) const {
     assert(nodeNum == from || nodeNum == to);
     return nodeNum == from ? to : from;
@@ -96,43 +96,43 @@ public:
   void DelScsrLst();
 
   // Adds a new edge to the successor list.
-  __host__ __device__
+  __host__
   void ApndScsr(GraphEdge *edge);
   // Adds a new edge to the successor list and does some magic.
   // TODO(max): Elaborate on magic.
-  __host__ __device__
+  __host__
   void AddScsr(GraphEdge *edge);
   // Adds a new node as a recursive successor.
-  __host__ __device__
+  __host__
   void AddRcrsvScsr(GraphNode *node);
-  __host__ __device__
+  __host__
   void AddRcrsvScsr(InstCount nodeNum);
   // Removes the last edge from the successor list and optionally deletes
   // the edge object. scsr must be the destination node of that edge.
-  __host__ __device__
+  __host__
   void RmvLastScsr(GraphNode *scsr, bool delEdg);
   // Returns the number of edges in this node's successor list.
-  __host__ __device__
+  __host__
   UDT_GEDGES GetScsrCnt() const;
 
   // Adds a new edge to the predecessor list.
-  __host__ __device__
+  __host__
   void ApndPrdcsr(GraphEdge *edge);
   // Adds a new edge to the predecessor list and does some magic.
   // TODO(max): Elaborate on magic.
-  __host__ __device__
+  __host__
   void AddPrdcsr(GraphEdge *edge);
   // Adds a new node as a recursive predecessor.
-  __host__ __device__
+  __host__
   void AddRcrsvPrdcsr(GraphNode *node);
-  __host__ __device__
+  __host__
   void AddRcrsvPrdcsr(InstCount nodeNum);
   // Removes the last edge from the predecessor list and optionally deletes
   // the edge object. scsr must be the destination node of that edge.
-  __host__ __device__
+  __host__
   void RmvLastPrdcsr(GraphNode *prdcsr, bool delEdg);
   // Returns the number of edges in this node's predecessor list.
-  __host__ __device__
+  __host__
   UDT_GEDGES GetPrdcsrCnt() const;
 
   // Sets the maximum outgoing edge label value to the maximum between the
@@ -161,20 +161,20 @@ public:
   // Returns a pointer to the first successor of the node and writes the label
   // of the edge between them to the label argument. Sets the successor
   // iterator.
-  __host__ __device__
+  __host__
   GraphNode *GetFrstScsr(UDT_GLABEL &label);
   // Returns a pointer to the next successor of the node and writes the label
   // of the edge between them to the label argument. Must be called after
   // GetFrstScsr() which starts the successor iterator.
-  __host__ __device__
+  __host__
   GraphNode *GetNxtScsr(UDT_GLABEL &label);
   // Returns a pointer to the first successor of the node. Sets the successor
   // iterator.
-  __host__ __device__
+  __host__
   GraphNode *GetFrstScsr();
   // Returns a pointer to the next successor of the node. Must be called after
   // GetFrstScsr() which starts the successor iterator.
-  __host__ __device__
+  __host__
   GraphNode *GetNxtScsr();
   // Checks if a given node is successor-equivalent to this node. Two nodes
   // are successor-equivalent if they have identical successor lists.
@@ -182,11 +182,11 @@ public:
   bool IsScsrEquvlnt(GraphNode *othrNode);
   // Returns a pointer to the first Predecesor of the node. Sets the predecesor
   // iterator.
-  __host__ __device__
+  __host__
   GraphNode *GetFrstPrdcsr(UDT_GLABEL &label);
   // Returns a pointer to the next predecessor of the node. Must be called after
   // GetFrstPrdcsr() which starts the predecessor iterator.
-  __host__ __device__
+  __host__ 
  GraphNode *GetNxtPrdcsr(UDT_GLABEL &label);
   // Checks if a given node is predecessor-equivalent to this node. Two nodes
   // are predecessor-equivalent if they have identical predecessor lists.
@@ -233,6 +233,7 @@ public:
   bool IsRoot() const;
   // Sets a bool to check if this node is root on the device
   void SetDevIsRoot();
+  void SetDevIsLeaf(bool isLeaf);
   // Returns whether this node is a leaf (i.e. has no successor).
   __host__ __device__
   bool IsLeaf() const;
@@ -253,7 +254,7 @@ public:
   void AllocRcrsvInfo(DIRECTION dir, UDT_GNODES nodeCnt);
   // Returns the node's recursive predecessor or successor list, depending on
   // the specified direction.
-  __host__ __device__
+  __host__
   ArrayList<InstCount> *GetRcrsvNghbrLst(DIRECTION dir);
   // Returns the node's recursive predecessor or successor bitset, depending
   // on the specified direction. Nodes which are in the list have the bits
@@ -276,11 +277,11 @@ public:
 
   // Returns the number of predecessors in this instruction's transitive
   // closure (i.e. total number of ancestors).
-  __host__ __device__
+  __host__
   UDT_GEDGES GetRcrsvPrdcsrCnt() const;
   // Returns the number of successors in this instruction's transitive
   // closure (i.e. total number of descendants).
-  __host__ __device__
+  __host__
   UDT_GEDGES GetRcrsvScsrCnt() const;
 
   // Resets node to default state, used for dev_maxDDG
@@ -330,6 +331,8 @@ private:
   // A bool to determine if this node is a root on the device
   bool dev_IsRoot;
 
+  bool dev_IsLeaf;
+
 protected:
   // A list of the immediate successors of this node.
   PriorityArrayList<GraphEdge *> *scsrLst_;
@@ -353,34 +356,34 @@ protected:
 
   // Returns the node's predecessor or successor list, depending on
   // the specified direction.
-  __host__ __device__
+  __host__
   ArrayList<GraphEdge *> *GetNghbrLst(DIRECTION dir);
 
   // Returns a pointer to the edge for the first successor of the node. Sets the
   // successor iterator.
-  __host__ __device__
+  __host__
   GraphEdge *GetFrstScsrEdge();
   // Returns a pointer to the edge for the next successor of the node. Must be
   // called after GetFrstScsr() or GetFrstScsrEdge(), which starts the successor
   // iterator.
-  __host__ __device__
+  __host__
   GraphEdge *GetNxtScsrEdge();
-  __host__ __device__
+  __host__
   GraphEdge *GetLastScsrEdge();
-  __host__ __device__
+  __host__
   GraphEdge *GetPrevScsrEdge();
   // Returns a pointer to the edge for the first predecessor of the node. Sets
   // the predecessor iterator.
-  __host__ __device__
+  __host__
   GraphEdge *GetFrstPrdcsrEdge();
   // Returns a pointer to the edge for the next predecessor of the node. Must be
   // called after GetFrstPrdcsr() or GetFrstPrdcsrEdge(), which starts the
   // predecessor iterator.
-  __host__ __device__
+  __host__
   GraphEdge *GetNxtPrdcsrEdge();
-  __host__ __device__
+  __host__
   GraphEdge *GetLastPrdcsrEdge();
-  __host__ __device__
+  __host__
   GraphEdge *GetPrevPrdcsrEdge();
   // Sets num when instantiating a node
   __host__ __device__
@@ -475,16 +478,27 @@ inline bool GraphNode::IsRoot() const {
 
 inline void GraphNode::SetDevIsRoot() { dev_IsRoot = this->IsRoot(); }
 
-__host__ __device__
-inline bool GraphNode::IsLeaf() const { return scsrLst_->GetElmntCnt() == 0; }
+// Need to pass the value for now--GraphNode won't know its successor count on device.
+inline void GraphNode::SetDevIsLeaf(bool isLeaf) { 
+  dev_IsLeaf = isLeaf; 
+}
 
 __host__ __device__
+inline bool GraphNode::IsLeaf() const {
+    #ifdef __HIP_DEVICE_COMPILE__
+      return dev_IsLeaf;
+    #else      
+      return scsrLst_->GetElmntCnt() == 0; 
+    #endif
+}
+
+__host__
 inline void GraphNode::ApndScsr(GraphEdge *edge) {
   // assert(edge->from == this);
   scsrLst_->InsrtElmnt(edge, edge->to, true);
 }
 
-__host__ __device__
+__host__
 inline void GraphNode::AddScsr(GraphEdge *edge) {
   // assert(edge->from == this);
   UDT_GEDGES scsrNum = scsrLst_->GetElmntCnt();
@@ -497,25 +511,25 @@ inline void GraphNode::AddScsr(GraphEdge *edge) {
   }
 }
 
-__host__ __device__
+__host__
 inline void GraphNode::AddRcrsvPrdcsr(GraphNode *node) {
   rcrsvPrdcsrLst_->InsrtElmnt(node->GetNum());
   isRcrsvPrdcsr_->SetBit(node->GetNum());
 }
 
-__host__ __device__
+__host__
 inline void GraphNode::AddRcrsvPrdcsr(InstCount nodeNum) {
   rcrsvPrdcsrLst_->InsrtElmnt(nodeNum);
   isRcrsvPrdcsr_->SetBit(nodeNum);
 }
 
-__host__ __device__
+__host__
 inline void GraphNode::AddRcrsvScsr(GraphNode *node) {
   rcrsvScsrLst_->InsrtElmnt(node->GetNum());
   isRcrsvScsr_->SetBit(node->GetNum());
 }
 
-__host__ __device__
+__host__
 inline void GraphNode::AddRcrsvScsr(InstCount nodeNum) {
   rcrsvScsrLst_->InsrtElmnt(nodeNum);
   isRcrsvScsr_->SetBit(nodeNum);
@@ -527,7 +541,7 @@ inline void GraphNode::UpdtMaxEdgLbl(UDT_GLABEL label) {
     maxEdgLbl_ = label;
 }
 
-__host__ __device__
+__host__
 inline void GraphNode::RmvLastScsr(GraphNode *scsr, bool delEdg) {
   assert(scsrLst_->GetElmntCnt() > 0);
   // assert(scsrLst_->GetLastElmnt()->to == scsr);
@@ -537,13 +551,13 @@ inline void GraphNode::RmvLastScsr(GraphNode *scsr, bool delEdg) {
   scsrLst_->RmvLastElmnt();
 }
 
-__host__ __device__
+__host__
 inline void GraphNode::ApndPrdcsr(GraphEdge *edge) {
   // assert(edge->to == this);
   prdcsrLst_->InsrtElmnt(edge);
 }
 
-__host__ __device__
+__host__
 inline void GraphNode::AddPrdcsr(GraphEdge *edge) {
   // assert(edge->to == this);
   UDT_GEDGES prdcsrNum = prdcsrLst_->GetElmntCnt();
@@ -552,7 +566,7 @@ inline void GraphNode::AddPrdcsr(GraphEdge *edge) {
   prdcsrLblSum_ += edge->label;
 }
 
-__host__ __device__
+__host__
 inline void GraphNode::RmvLastPrdcsr(GraphNode *prdcsr, bool delEdg) {
   assert(prdcsrLst_->GetElmntCnt() > 0);
   // assert(prdcsrLst_->GetLastElmnt()->from == prdcsr);
@@ -565,12 +579,12 @@ inline void GraphNode::RmvLastPrdcsr(GraphNode *prdcsr, bool delEdg) {
 __host__ __device__
 inline void GraphNode::SetColor(GNODE_COLOR color) { color_ = color; }
 
-__host__ __device__
+__host__ 
 inline UDT_GEDGES GraphNode::GetPrdcsrCnt() const {
   return prdcsrLst_->GetElmntCnt();
 }
 
-__host__ __device__
+__host__
 inline UDT_GEDGES GraphNode::GetScsrCnt() const {
   return scsrLst_->GetElmntCnt();
 }
@@ -581,7 +595,7 @@ inline GNODE_COLOR GraphNode::GetColor() const { return color_; }
 __host__ __device__
 inline UDT_GNODES GraphNode::GetNum() const { return num_; }
 
-__host__ __device__
+__host__
 inline GraphNode *GraphNode::GetFrstScsr(UDT_GLABEL &label) {
   GraphEdge *edge = scsrLst_->GetFrstElmnt();
   if (edge == NULL)
@@ -590,7 +604,7 @@ inline GraphNode *GraphNode::GetFrstScsr(UDT_GLABEL &label) {
   return nodes_[edge->to];
 }
 
-__host__ __device__
+__host__
 inline GraphNode *GraphNode::GetNxtScsr(UDT_GLABEL &label) {
   GraphEdge *edge = scsrLst_->GetNxtElmnt();
   if (edge == NULL)
@@ -599,7 +613,7 @@ inline GraphNode *GraphNode::GetNxtScsr(UDT_GLABEL &label) {
   return nodes_[edge->to];
 }
 
-__host__ __device__
+__host__
 inline GraphNode *GraphNode::GetFrstPrdcsr(UDT_GLABEL &label) {
   GraphEdge *edge = prdcsrLst_->GetFrstElmnt();
   if (edge == NULL)
@@ -608,7 +622,7 @@ inline GraphNode *GraphNode::GetFrstPrdcsr(UDT_GLABEL &label) {
   return nodes_[edge->to];
 }
 
-__host__ __device__
+__host__
 inline GraphNode *GraphNode::GetNxtPrdcsr(UDT_GLABEL &label) {
   GraphEdge *edge = prdcsrLst_->GetNxtElmnt();
   if (edge == NULL)
@@ -617,13 +631,13 @@ inline GraphNode *GraphNode::GetNxtPrdcsr(UDT_GLABEL &label) {
   return nodes_[edge->to];
 }
 
-__host__ __device__
+__host__
 inline GraphNode *GraphNode::GetFrstScsr() {
   UDT_GLABEL label;
   return GetFrstScsr(label);
 }
 
-__host__ __device__
+__host__
 inline GraphNode *GraphNode::GetNxtScsr() {
   UDT_GLABEL label;
   return GetNxtScsr(label);
@@ -641,7 +655,7 @@ inline UDT_GNODES GraphNode::GetTplgclOrdr() const { return tplgclOrdr_; }
 __host__ __device__
 inline UDT_GLABEL GraphNode::GetMaxEdgeLabel() const { return maxEdgLbl_; }
 
-__host__ __device__
+__host__
 inline ArrayList<InstCount> *GraphNode::GetRcrsvNghbrLst(DIRECTION dir) {
   return dir == DIR_FRWRD ? rcrsvScsrLst_ : rcrsvPrdcsrLst_;
 }
@@ -676,57 +690,57 @@ inline bool GraphNode::IsRcrsvNghbr(DIRECTION dir, GraphNode *node) const {
   }
 }
 
-__host__ __device__
+__host__
 inline UDT_GEDGES GraphNode::GetRcrsvPrdcsrCnt() const {
   return rcrsvPrdcsrLst_->GetElmntCnt();
 }
 
-__host__ __device__
+__host__
 inline UDT_GEDGES GraphNode::GetRcrsvScsrCnt() const {
   return rcrsvScsrLst_->GetElmntCnt();
 }
 
-__host__ __device__
+__host__
 inline ArrayList<GraphEdge *> *GraphNode::GetNghbrLst(DIRECTION dir) {
   return dir == DIR_FRWRD ? prdcsrLst_ : scsrLst_;
 }
 
-__host__ __device__
+__host__
 inline GraphEdge *GraphNode::GetFrstScsrEdge() {
   return scsrLst_->GetFrstElmnt();
 }
 
-__host__ __device__
+__host__
 inline GraphEdge *GraphNode::GetNxtScsrEdge() {
   return scsrLst_->GetNxtElmnt();
 }
 
-__host__ __device__
+__host__
 inline GraphEdge *GraphNode::GetLastScsrEdge() {
   return scsrLst_->GetLastElmnt();
 }
 
-__host__ __device__
+__host__
 inline GraphEdge *GraphNode::GetPrevScsrEdge() {
   return scsrLst_->GetPrevElmnt();
 }
 
-__host__ __device__
+__host__
 inline GraphEdge *GraphNode::GetFrstPrdcsrEdge() {
   return prdcsrLst_->GetFrstElmnt();
 }
 
-__host__ __device__
+__host__
 inline GraphEdge *GraphNode::GetNxtPrdcsrEdge() {
   return prdcsrLst_->GetNxtElmnt();
 }
 
-__host__ __device__
+__host__
 inline GraphEdge *GraphNode::GetLastPrdcsrEdge() {
   return prdcsrLst_->GetLastElmnt();
 }
 
-__host__ __device__
+__host__
 inline GraphEdge *GraphNode::GetPrevPrdcsrEdge() {
   return prdcsrLst_->GetPrevElmnt();
 }

--- a/include/opt-sched/Scheduler/graph.h
+++ b/include/opt-sched/Scheduler/graph.h
@@ -289,10 +289,7 @@ public:
   void Reset();
 
   // Copy GraphNode arrays/pointers to device
-  void CopyPointersToDevice(GraphNode *dev_node, GraphNode **dev_nodes,
-		            InstCount instCnt, std::vector<GraphEdge *> *edges,
-                            GraphEdge *dev_edges, GraphEdge **dev_scsrElmnts_, 
-                            unsigned long *dev_keys, int &scsrIndex);
+  void CopyPointersToDevice(GraphNode *dev_node, GraphNode **dev_nodes);
   // Calls hipFree on all arrays/objects that were allocated with hipMalloc
   void FreeDevicePointers();
 

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -225,14 +225,14 @@ public:
   //     successor list.
   //   ltncy: the latency from the predecessor to this instruction.
   //   depType: the type of dependence between this node and the predecessor.
-  __host__ __device__
+  __host__
   SchedInstruction *GetFrstPrdcsr(InstCount *scsrNum = NULL,
                                   UDT_GLABEL *ltncy = NULL,
                                   DependenceType *depType = NULL,
 				  InstCount *toNodeNum = NULL);
   // Returns the next predecessor of this instruction node and moves the
   // predecessor iterator forward. Fills parameters as above.
-  __host__ __device__
+  __host__
   SchedInstruction *GetNxtPrdcsr(InstCount *scsrNum = NULL,
                                  UDT_GLABEL *ltncy = NULL,
                                  DependenceType *depType = NULL,
@@ -245,7 +245,7 @@ public:
   //     predecessor list.
   //   ltncy: the latency from this instruction to the successor.
   //   depType: the type of dependence between this node and the successor.
-  __host__ __device__
+  __host__
   SchedInstruction *GetFrstScsr(InstCount *prdcsrNum = NULL,
                                 UDT_GLABEL *ltncy = NULL,
                                 DependenceType *depType = NULL,
@@ -253,7 +253,7 @@ public:
                                 bool *IsArtificial = nullptr);
   // Returns the next successor of this instruction node and moves the
   // successor iterator forward. Fills parameters as above.
-  __host__ __device__
+  __host__
   SchedInstruction *GetNxtScsr(InstCount *prdcsrNum = NULL,
                                UDT_GLABEL *ltncy = NULL,
                                DependenceType *depType = NULL,
@@ -264,24 +264,24 @@ public:
   // successor iterator to the end of the list. If prdcsrNum is provided, this
   // instruction's number (order) in the successor's predecessor list is
   // written to it.
-  __host__ __device__
+  __host__
   SchedInstruction *GetLastScsr(InstCount *prdcsrNum = NULL);
   // Returns the previous predecessor of this instruction node and moves the
   // predecessor iterator backward. Fills prdcsrNum as above.
-  __host__ __device__
+  __host__
   SchedInstruction *GetPrevScsr(InstCount *prdcsrNum = NULL);
 
   // Returns the first predecessor or successor of this instruction node,
   // depending on the value of dir, filling in the latency from the
   // predecessor to this instruction into ltncy, if provided. Resets the
   // predecessor or successor iterator (the two iterator are independent).
-  __host__ __device__
+  __host__
   SchedInstruction *GetFrstNghbr(DIRECTION dir, UDT_GLABEL *ltncy = NULL);
   // Returns the next predecessor or successor of this instruction node,
   // depending on the value of dir, filling in the latency from the
   // predecessor to this instruction into ltncy, if provided. Moves the
   // predecessor iterator forward (the two iterator are independent).
-  __host__ __device__
+  __host__
   SchedInstruction *GetNxtNghbr(DIRECTION dir, UDT_GLABEL *ltncy = NULL);
   /***************************************************************************/
 
@@ -309,13 +309,13 @@ public:
   // Calculates the instruction's critical path distance from the root,
   // assuming that the critical paths of all of its predecessors have been
   // calculated.
-  __host__ __device__
+  __host__
   InstCount CmputCrtclPathFrmRoot();
 
   // Calculates the instruction's critical path distance from the leaf,
   // assuming that the critical paths of all of its successors have been
   // calculated.
-  __host__ __device__
+  __host__
   InstCount CmputCrtclPathFrmLeaf();
 
   // Returns the critical path distance of this instruction from the root of
@@ -400,19 +400,19 @@ public:
   // is added to the given list to be used for efficient untightening. This
   // function returns with false as soon as infeasiblity (w.r.t the given
   // schedule length) is detected, otherwise it returns true.
-  __host__ __device__
+  __host__
   bool TightnLwrBound(DIRECTION dir, InstCount newLwrBound,
                       LinkedList<SchedInstruction> *tightndLst,
                       LinkedList<SchedInstruction> *fxdLst, bool enforce);
   // Like TightnLwrBound(), but also recursively propagates tightening through
   // the subgraph rooted at this instruction.
-  __host__ __device__
+  __host__
   bool TightnLwrBoundRcrsvly(DIRECTION dir, InstCount newLwrBound,
                              LinkedList<SchedInstruction> *tightndLst,
                              LinkedList<SchedInstruction> *fxdLst,
                              bool enforce);
   // Untightens any tightened lower bound.
-  __host__ __device__
+  __host__
   void UnTightnLwrBounds();
   // Marks the instruction as not tightened.
   __host__ __device__
@@ -434,7 +434,7 @@ public:
 
   // Tightens the lower bound and deadline and recursively propagates these
   // tightenings to the neighbors and checking for feasibility at each point.
-  __host__ __device__
+  __host__
   bool ApplyPreFxng(LinkedList<SchedInstruction> *tightndLst,
                     LinkedList<SchedInstruction> *fxdLst);
 
@@ -445,7 +445,7 @@ public:
   // Probes the successors of this instruction to see if their current lower
   // bounds will get tightened (delayed) if this instruction was scheduled in
   // the given cycle.
-  __host__ __device__
+  __host__
   bool ProbeScsrsCrntLwrBounds(InstCount cycle);
 
   /***************************************************************************
@@ -459,13 +459,13 @@ public:
   // Calculates the instruction's critical path distance from the given entry
   // node assuming that the critical paths of all of its predecessors have
   // been calculated.
-  __host__ __device__
+  __host__
   InstCount CmputCrtclPathFrmRcrsvPrdcsr(SchedInstruction *ref);
 
   // Calculates the instruction's critical path distance from the given exit
   // node assuming that the critical paths of all of its successors have been
   // calculated.
-  __host__ __device__
+  __host__
   InstCount CmputCrtclPathFrmRcrsvScsr(SchedInstruction *ref);
   /***************************************************************************/
 
@@ -561,6 +561,29 @@ public:
   void AllocDevArraysForParallelACO(int numThreads);
 
   friend class SchedRange;
+
+  // array of nodes_ indices referring to this instruction's successors.
+  int* scsrs_;
+  // array of latencies of this instruction's successors.
+  int* latencies_;
+  // array of this instruction's order in the predecessor lists of each of its successors.
+  int* predOrder_;
+
+  // Returns the successor of this instruction node given by the scsrNum
+  // (its index in scsrs_). Fills prdcsrNum, ltncy, and scsrNodeNum (the
+  // instruction's index in nodes_) if provided.
+  __host__ __device__
+  SchedInstruction *GetScsr(int scsrNum, 
+                            InstCount *prdcsrNum = NULL, 
+                            UDT_GLABEL *ltncy = NULL,
+                            InstCount *scsrNodeNum = NULL);
+
+  __device__
+  int GetScsrCnt_();
+
+  __host__
+  void SetupForDevice();
+
 
 protected:
   // The "name" of this instruction. Usually a string indicating its type.
@@ -733,7 +756,7 @@ protected:
   bool mustBeInBBExit_;
 
   // TODO(ghassan): Document.
-  __host__ __device__
+  __host__
   InstCount CmputCrtclPath_(DIRECTION dir, SchedInstruction *ref = NULL);
   // Allocate the memory needed for data structures used in this node.
   // Arguments as follows:
@@ -749,11 +772,11 @@ protected:
   void DeAllocMem_();
   // Sets the predecessor order numbers on the edges between this node and its
   // predecessors.
-  __host__ __device__
+  __host__
   void SetPrdcsrNums_();
   // Sets the successor order numbers on the edges between this node and its
   // successors.
-  __host__ __device__
+  __host__
   void SetScsrNums_();
   // Computer the adjusted use count. Update "adjustedUseCnt_".
   __host__ __device__
@@ -792,13 +815,13 @@ public:
   // added to the given list to be used for efficient untightening. This
   // function returns with false as soon as infeasiblity (w.r.t the given
   // schedule length) is detected, otherwise it returns true.
-  __host__ __device__
+  __host__
   bool TightnLwrBound(DIRECTION dir, InstCount newLwrBound,
                       LinkedList<SchedInstruction> *tightndLst,
                       LinkedList<SchedInstruction> *fxdLst, bool enforce);
   // Like TightnLwrBound(), but also recursively propagates tightening through
   // the subgraph rooted at the instruction using this range.
-  __host__ __device__
+  __host__
   bool TightnLwrBoundRcrsvly(DIRECTION dir, InstCount newLwrBound,
                              LinkedList<SchedInstruction> *tightndLst,
                              LinkedList<SchedInstruction> *fxdLst,
@@ -817,13 +840,13 @@ public:
   __host__ __device__
   bool IsFxd() const;
   // Untightens any tightened lower bound.
-  __host__ __device__
+  __host__
   void UnTightnLwrBounds();
   // Marks the range as not tightened.
   __host__ __device__
   void CmtLwrBoundTightnng();
   // TODO(ghassan): Document.
-  __host__ __device__
+  __host__
   bool Fix(InstCount cycle, LinkedList<SchedInstruction> *tightndLst,
            LinkedList<SchedInstruction> *fxdLst);
   // Returns whether the range is tightened in the given direction.

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -548,12 +548,12 @@ public:
 
   // Copies pointers to device and links them to device inst. Also uses
   // the device nodes_ array to set nodes_ in GraphNode
-  void CopyPointersToDevice(SchedInstruction *dev_inst, GraphNode **dev_nodes, 
-		            InstCount instCnt, RegisterFile *dev_regFiles, 
-                            int numThreads, std::vector<GraphEdge *> *edges,
-                            GraphEdge *dev_edges, GraphEdge **dev_scsrElmnts_, 
-                            unsigned long *dev_keys, int &scsrIndex,
-                            InstCount *dev_ltncyPerPrdcsr, int &ltncyIndex);
+  void CopyPointersToDevice(SchedInstruction *dev_inst,
+                            GraphNode **dev_nodes,
+                            RegisterFile *dev_regFiles,
+                            int numThreads, 
+                            InstCount *dev_ltncyPerPrdcsr,
+                            int &ltncyIndex);
   // Calls hipFree on all arrays/objects that were allocated with hipMalloc
   void FreeDevicePointers(int numThreads);
   // Allocates arrays used for storing individual values for each thread in

--- a/lib/Scheduler/aco.hip.cpp
+++ b/lib/Scheduler/aco.hip.cpp
@@ -586,7 +586,6 @@ InstSchedule *ACOScheduler::FindOneSchedule(InstCount RPTarget,
         printf("cyclenum: %d Close to RP Target: %s\n", dev_crntCycleNum_[GLOBALTID], closeToRPTarget ? "true" : "false");
       }
       #endif
-      int totalstalls__ = schedule->getTotalStalls();
       // select the instruction and get info on it
       InstCount SelIndx = SelectInstruction(lastInst, schedule->getTotalStalls(), dev_rgn_, unnecessarilyStalling, closeToRPTarget, waitFor ? true: false);
 

--- a/lib/Scheduler/aco.hip.cpp
+++ b/lib/Scheduler/aco.hip.cpp
@@ -554,7 +554,6 @@ InstSchedule *ACOScheduler::FindOneSchedule(InstCount RPTarget,
   lastInst = dataDepGraph_->GetInstByIndx(RootId);
   bool closeToRPTarget = false;
   dev_RP0OrPositiveCount[GLOBALTID] = 0;
-
   while (!IsSchedComplete_()) {
     // incrementally calculate if there are any instructions with a neutral
     // or positive effect on RP
@@ -587,7 +586,7 @@ InstSchedule *ACOScheduler::FindOneSchedule(InstCount RPTarget,
         printf("cyclenum: %d Close to RP Target: %s\n", dev_crntCycleNum_[GLOBALTID], closeToRPTarget ? "true" : "false");
       }
       #endif
-
+      int totalstalls__ = schedule->getTotalStalls();
       // select the instruction and get info on it
       InstCount SelIndx = SelectInstruction(lastInst, schedule->getTotalStalls(), dev_rgn_, unnecessarilyStalling, closeToRPTarget, waitFor ? true: false);
 
@@ -1582,8 +1581,9 @@ inline void ACOScheduler::UpdateACOReadyList(SchedInstruction *inst) {
       printf("successors of %d:", inst->GetNum());
     }
     #endif
-    for (SchedInstruction *crntScsr = inst->GetFrstScsr(&prdcsrNum);
-          crntScsr != NULL; crntScsr = inst->GetNxtScsr(&prdcsrNum)) {
+    int i = 0;
+    for (SchedInstruction *crntScsr = inst->GetScsr(i++, &prdcsrNum);
+          crntScsr != NULL; crntScsr = inst->GetScsr(i++, &prdcsrNum)) {
         #ifdef DEBUG_INSTR_SELECTION
         if (GLOBALTID==0) {
           printf(" %d,", crntScsr->GetNum());

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -100,7 +100,7 @@ static inline void addDblQuotes(const char *src, int srcLen, char *dest) {
   dest[srcLen + 2] = '\0';
 }
 
-__host__ __device__
+__host__
 InstCount DataDepStruct::CmputRsrcLwrBound_() {
   // Temp limitation
   assert(type_ == DGT_FULL);
@@ -142,7 +142,7 @@ InstCount DataDepStruct::CmputRsrcLwrBound_() {
   return rsrcLwrBound;
 }
 
-__host__ __device__
+__host__
 InstCount DataDepStruct::CmputAbslutUprBound_() {
   InstCount i;
   InstCount ltncySum = 0;
@@ -380,7 +380,7 @@ FUNC_RESULT DataDepGraph::UpdateSetupForSchdulng(bool cmputTrnstvClsr) {
   return RES_SUCCESS;
 }
 
-__host__ __device__
+__host__
 void DataDepGraph::CmputBasicLwrBounds_() {
   for (InstCount i = 0; i < instCnt_; i++) {
     SchedInstruction *inst = GetInstByIndx(i);
@@ -1224,7 +1224,7 @@ bool DataDepGraph::UseFileBounds() {
   return match;
 }
 
-__host__ __device__
+__host__
 void DataDepGraph::CmputRltvCrtclPaths_(DIRECTION dir) {
   InstCount i;
 
@@ -1241,7 +1241,7 @@ void DataDepGraph::CmputRltvCrtclPaths_(DIRECTION dir) {
   }
 }
 
-__host__ __device__
+__host__
 void DataDepGraph::CmputCrtclPathsFrmRcrsvPrdcsr_(SchedInstruction *ref) {
   ArrayList<InstCount> *rcrsvScsrLst = ref->GetRcrsvNghbrLst(DIR_FRWRD);
   SchedInstruction *inst = GetLeafInst();
@@ -1264,7 +1264,7 @@ void DataDepGraph::CmputCrtclPathsFrmRcrsvPrdcsr_(SchedInstruction *ref) {
          ref->GetCrtclPath(DIR_BKWRD));
 }
 
-__host__ __device__
+__host__
 void DataDepGraph::CmputCrtclPathsFrmRcrsvScsr_(SchedInstruction *ref) {
   ArrayList<InstCount> *rcrsvPrdcsrLst = ref->GetRcrsvNghbrLst(DIR_BKWRD);
   SchedInstruction *inst = GetRootInst();
@@ -3465,7 +3465,7 @@ SchedInstruction *DataDepGraph::GetLeafInst() {
   return (SchedInstruction *)leaf_;
 }
 
-__host__ __device__
+__host__
 void DataDepGraph::CmputCrtclPathsFrmRoot_() {
   InstCount i;
 
@@ -3475,7 +3475,7 @@ void DataDepGraph::CmputCrtclPathsFrmRoot_() {
   }
 }
 
-__host__ __device__
+__host__
 void DataDepGraph::CmputCrtclPathsFrmLeaf_() {
   InstCount i;
 
@@ -3485,7 +3485,7 @@ void DataDepGraph::CmputCrtclPathsFrmLeaf_() {
   }
 }
 
-__host__ __device__
+__host__
 void DataDepGraph::CmputCrtclPaths_() {
   CmputCrtclPathsFrmRoot_();
   CmputCrtclPathsFrmLeaf_();
@@ -3704,23 +3704,7 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   // Also copy each RegFile's pointers
   for (InstCount i = 0; i < machMdl_->GetRegTypeCnt(); i++)
     RegFiles[i].CopyPointersToDevice(&dev_DDG->RegFiles[i]);
-  // Collect all GraphEdges into one host array, copy it to device
-  Logger::Info("Copying all edges to device");
-  // First sort the vector of edges to allow for a binary search
-  std::sort(edges_->begin(), edges_->end());
-  memSize = sizeof(GraphEdge) * edges_->size();
-  // Will hold all host edges in one array to be copied to device in one copy
-  GraphEdge *host_edges = (GraphEdge *)malloc(memSize);
-  gpuErrchk(hipMalloc(&dev_edges_, memSize));
-  // iterate through all pointers to edges and copy them into one host array
-  memSize = sizeof(GraphEdge);
-  for (uint i = 0; i < edges_->size(); i++)
-    memcpy(&host_edges[i], edges_->at(i), memSize);
-  // Copy host_edges to device and delete the host_edges array
-  memSize = sizeof(GraphEdge) * edges_->size();
-  gpuErrchk(hipMemcpy(dev_edges_, host_edges, memSize, 
-                       hipMemcpyHostToDevice));
-  free(host_edges);
+  
 
   Logger::Info("Copying SchedInstructions to device");
   // count the number of elements in predecessor/successor lists
@@ -3731,11 +3715,6 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
     lngthScsrElmnts += insts_[i].GetScsrCnt();
     lengthLatencies += insts_[i].GetPrdcsrCnt();
   }
-  memSize = sizeof(GraphEdge *) * lngthScsrElmnts;
-  gpuErrchk(hipMallocManaged(&dev_scsrElmnts_, memSize));
-
-  memSize = sizeof(unsigned long) * lngthScsrElmnts;
-  gpuErrchk(hipMallocManaged(&dev_keys_, memSize));
 
   memSize = sizeof(InstCount) * lengthLatencies;
   gpuErrchk(hipMallocManaged(&dev_latencies_, memSize));
@@ -3756,10 +3735,6 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   gpuErrchk(hipMemPrefetchAsync(dev_insts, memSize, 0));
   memSize = sizeof(RegisterFile) * machMdl_->GetRegTypeCnt();
   gpuErrchk(hipMemPrefetchAsync(dev_regFiles, memSize, 0));
-  memSize = sizeof(GraphEdge *) * lngthScsrElmnts;
-  gpuErrchk(hipMemPrefetchAsync(dev_scsrElmnts_, memSize, 0));
-  memSize = sizeof(unsigned long) * lngthScsrElmnts;
-  gpuErrchk(hipMemPrefetchAsync(dev_keys_, memSize, 0));
   memSize = sizeof(InstCount) * lengthLatencies;
   gpuErrchk(hipMemPrefetchAsync(dev_latencies_, memSize, 0));
 }

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -3726,10 +3726,7 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   // and update RegFiles pointer to dev_regFiles
   for (InstCount i = 0; i < instCnt_; i++)
     insts_[i].CopyPointersToDevice(&dev_DDG->insts_[i], dev_DDG->nodes_, 
-		                   instCnt_, dev_regFiles, numThreads,
-                                   edges_, dev_edges_,
-                                   dev_scsrElmnts_,
-                                   dev_keys_, scsrIndex,
+                                   dev_regFiles, numThreads,
                                    dev_latencies_, latencyIndex);
   memSize = sizeof(SchedInstruction) * instCnt_;
   gpuErrchk(hipMemPrefetchAsync(dev_insts, memSize, 0));

--- a/lib/Scheduler/graph.hip.cpp
+++ b/lib/Scheduler/graph.hip.cpp
@@ -376,14 +376,8 @@ int compareGEptr(const void * a, const void * b) {
     return 0;
 }
 
-// TODO(bruce) fix method signature
-void GraphNode::CopyPointersToDevice(GraphNode *dev_node, GraphNode **dev_nodes,
-                                     InstCount instCnt, 
-                                     std::vector<GraphEdge *> *edges,
-                                     GraphEdge *dev_edges,
-                                     GraphEdge **dev_scsrElmnts, 
-                                     unsigned long *dev_keys, 
-                                     int &scsrIndex) {  
+void GraphNode::CopyPointersToDevice(GraphNode *dev_node, 
+                                     GraphNode **dev_nodes) {  
   //set value of nodes_ to dev_insts_
   dev_node->nodes_ = dev_nodes;
 }

--- a/lib/Scheduler/graph.hip.cpp
+++ b/lib/Scheduler/graph.hip.cpp
@@ -25,6 +25,7 @@ GraphNode::GraphNode(UDT_GNODES num, UDT_GNODES maxNodeCnt) {
   isRcrsvPrdcsr_ = NULL;
 
   dev_IsRoot = false;
+  dev_IsLeaf = false;
 }
 
 __host__ __device__
@@ -40,6 +41,7 @@ GraphNode::GraphNode() {
   isRcrsvPrdcsr_ = NULL;
 
   dev_IsRoot = false;
+  dev_IsLeaf = false;
 }
 
 __host__
@@ -374,49 +376,14 @@ int compareGEptr(const void * a, const void * b) {
     return 0;
 }
 
+// TODO(bruce) fix method signature
 void GraphNode::CopyPointersToDevice(GraphNode *dev_node, GraphNode **dev_nodes,
                                      InstCount instCnt, 
                                      std::vector<GraphEdge *> *edges,
                                      GraphEdge *dev_edges,
                                      GraphEdge **dev_scsrElmnts, 
                                      unsigned long *dev_keys, 
-                                     int &scsrIndex) {
-  size_t memSize;
-  int index;
-  void *ptrToEdge;
-  // Copy scsrLst_ to device
-  PriorityArrayList<GraphEdge *> *dev_scsrLst;
-  memSize = sizeof(PriorityArrayList<GraphEdge *>);
-  gpuErrchk(hipMallocManaged(&dev_scsrLst, memSize));
-  gpuErrchk(hipMemcpy(dev_scsrLst, scsrLst_, memSize, hipMemcpyHostToDevice));
-  gpuErrchk(hipMemcpy(&dev_node->scsrLst_, &dev_scsrLst,
-		       sizeof(PriorityArrayList<GraphEdge *> *),
-		       hipMemcpyHostToDevice));
-  // Copy elmnts_ and keys
-  if (scsrLst_->maxSize_ > 0) {
-    dev_node->scsrLst_->keys_ = &dev_keys[scsrIndex];
-    for (InstCount i = 0; i < scsrLst_->size_; i++) {
-      dev_node->scsrLst_->keys_[i] = scsrLst_->keys_[i];
-    }
-    dev_node->scsrLst_->elmnts_ = &dev_scsrElmnts[scsrIndex];
-    scsrIndex += dev_node->scsrLst_->size_;
-    // update elmnts_ pointers to dev array
-    for (InstCount i = 0; i < scsrLst_->size_; i++) {
-      // find the matching pointer in the array of edge pointers
-      ptrToEdge = std::bsearch(&scsrLst_->elmnts_[i], &(*edges)[0], edges->size(),
-		               sizeof(GraphEdge *), compareGEptr);
-      if (!ptrToEdge)
-        Logger::Fatal("Failed to find matching edge in scsrLst");
-      else
-	      index = ((GraphEdge **)ptrToEdge - (GraphEdge **)&(*edges)[0]);
-      // set the dev_scsrElmnts pointer to the corresponding dev_edges pointer
-      dev_node->scsrLst_->elmnts_[i] = &dev_edges[index];
-    }
-    // New dev_edges values are copied before kernel start in DataDepGraph
-  }
-  memSize = sizeof(PriorityArrayList<GraphEdge *>);
-  gpuErrchk(hipMemPrefetchAsync(dev_scsrLst, memSize, 0));
-  
+                                     int &scsrIndex) {  
   //set value of nodes_ to dev_insts_
   dev_node->nodes_ = dev_nodes;
 }

--- a/lib/Scheduler/ready_list.hip.cpp
+++ b/lib/Scheduler/ready_list.hip.cpp
@@ -106,7 +106,11 @@ HeurType KeysHelper::computeKey(SchedInstruction *Inst, bool IncludeDynamic) con
       break;
 
     case LSH_SC:
+      #ifdef __HIP_DEVICE_COMPILE__
+      PriorityValue = Inst->GetScsrCnt_();
+      #else
       PriorityValue = Inst->GetScsrCnt();
+      #endif
       break;
 
     case LSH_LS:

--- a/lib/Scheduler/sched_basic_data.hip.cpp
+++ b/lib/Scheduler/sched_basic_data.hip.cpp
@@ -439,6 +439,7 @@ int SchedInstruction::GetLtncySum() const {
   for (int i = 0; i < scsrCnt_; i++) {
     sum += latencies_[i];
   }
+  return sum;
   #else 
   return GetScsrLblSum(); 
   #endif
@@ -454,6 +455,7 @@ int SchedInstruction::GetMaxLtncy() const {
       max = latencies_[i];
     }
   }
+  return max;
   #else  
   return GetMaxEdgeLabel();
   #endif
@@ -472,7 +474,7 @@ __host__
 SchedInstruction *SchedInstruction::GetFrstPrdcsr(InstCount *scsrNum,
                                                   UDT_GLABEL *ltncy,
                                                   DependenceType *depType,
-						                                      InstCount *toNodeNum) {
+                                                  InstCount *toNodeNum) {
   GraphEdge *edge = GetFrstPrdcsrEdge();
   if (!edge)
     return NULL;
@@ -491,7 +493,7 @@ __host__
 SchedInstruction *SchedInstruction::GetNxtPrdcsr(InstCount *scsrNum,
                                                  UDT_GLABEL *ltncy,
                                                  DependenceType *depType,
-						                                     InstCount *toNodeNum) {
+                                                 InstCount *toNodeNum) {
   GraphEdge *edge = GetNxtPrdcsrEdge();
   if (!edge)
     return NULL;
@@ -537,7 +539,7 @@ __host__
 SchedInstruction *SchedInstruction::GetFrstScsr(InstCount *prdcsrNum,
                                                 UDT_GLABEL *ltncy,
                                                 DependenceType *depType,
-						                                    InstCount *toNodeNum,
+                                                InstCount *toNodeNum,
                                                 bool *IsArtificial) {
   GraphEdge *edge = GetFrstScsrEdge();
   if (!edge)
@@ -559,7 +561,7 @@ __host__
 SchedInstruction *SchedInstruction::GetNxtScsr(InstCount *prdcsrNum,
                                                UDT_GLABEL *ltncy,
                                                DependenceType *depType,
-					                                     InstCount *toNodeNum,
+                                               InstCount *toNodeNum,
                                                bool *IsArtificial) {
   GraphEdge *edge = GetNxtScsrEdge();
   if (!edge)

--- a/lib/Scheduler/sched_basic_data.hip.cpp
+++ b/lib/Scheduler/sched_basic_data.hip.cpp
@@ -1136,17 +1136,10 @@ void SchedInstruction::SetupForDevice() {
        }
 }
 
-// TODO(bruce) fix method signature
 void SchedInstruction::CopyPointersToDevice(SchedInstruction *dev_inst,
                                             GraphNode **dev_nodes,
-					                                  InstCount instCnt, 
 					                                  RegisterFile *dev_regFiles,
                                             int numThreads, 
-                                            std::vector<GraphEdge *> *edges,
-                                            GraphEdge *dev_edges, 
-                                            GraphEdge **dev_scsrElmnts, 
-                                            unsigned long *dev_keys, 
-                                            int &scsrIndex,
                                             InstCount *dev_ltncyPerPrdcsr,
                                             int &ltncyIndex) {
   SetupForDevice();
@@ -1171,9 +1164,7 @@ void SchedInstruction::CopyPointersToDevice(SchedInstruction *dev_inst,
   }
   ltncyIndex += prdcsrCnt_;
 
-  GraphNode::CopyPointersToDevice((GraphNode *)dev_inst, dev_nodes, instCnt,
-                                  edges, dev_edges, dev_scsrElmnts, 
-                                  dev_keys, scsrIndex);
+  GraphNode::CopyPointersToDevice((GraphNode *)dev_inst, dev_nodes);
   
   // make sure managed mem is copied to device before kernel start
   memSize = sizeof(InstCount *) * numThreads;

--- a/lib/Scheduler/sched_basic_data.hip.cpp
+++ b/lib/Scheduler/sched_basic_data.hip.cpp
@@ -55,6 +55,10 @@ SchedInstruction::SchedInstruction(InstCount num, const char *name,
   crtclPathFrmRoot_ = INVALID_VALUE;
   crtclPathFrmLeaf_ = INVALID_VALUE;
 
+  int* scsrs_;
+  int* predOrder_;
+  int* latencies_;
+
   ltncyPerPrdcsr_ = NULL;
   memAllocd_ = false;
   sortedPrdcsrLst_ = NULL;
@@ -93,7 +97,6 @@ SchedInstruction::SchedInstruction(InstCount num, const char *name,
   mustBeInBBEntry_ = false;
   mustBeInBBExit_ = false;
 }
-
 __host__ __device__
 SchedInstruction::SchedInstruction()
   :GraphNode() {}
@@ -270,7 +273,7 @@ void SchedInstruction::DeAllocMem_() {
   memAllocd_ = false;
 }
 
-__host__ __device__
+__host__
 InstCount SchedInstruction::CmputCrtclPath_(DIRECTION dir,
                                             SchedInstruction *ref) {
   // The idea of this function is considering each predecessor (successor) and
@@ -306,7 +309,7 @@ InstCount SchedInstruction::CmputCrtclPath_(DIRECTION dir,
   return crtclPath;
 }
 
-__host__ __device__
+__host__
 bool SchedInstruction::ApplyPreFxng(LinkedList<SchedInstruction> *tightndLst,
                                     LinkedList<SchedInstruction> *fxdLst) {
   return crntRange_->Fix(preFxdCycle_, tightndLst, fxdLst);
@@ -428,11 +431,33 @@ int SchedInstruction::GetNodeID() const { return nodeID_; }
 __host__ __device__
 void SchedInstruction::SetNodeID(int nodeID) { nodeID_ = nodeID; }
 
+// TODO(bruce) consider storing this value in SetupForDevice instead of recomputing
 __host__ __device__
-int SchedInstruction::GetLtncySum() const { return GetScsrLblSum(); }
+int SchedInstruction::GetLtncySum() const {
+  #ifdef __HIP_DEVICE_COMPILE__
+  int sum = 0;
+  for (int i = 0; i < scsrCnt_; i++) {
+    sum += latencies_[i];
+  }
+  #else 
+  return GetScsrLblSum(); 
+  #endif
+  }
 
+// TODO(bruce) consider storing this value in SetupForDevice instead of recomputing
 __host__ __device__
-int SchedInstruction::GetMaxLtncy() const { return GetMaxEdgeLabel(); }
+int SchedInstruction::GetMaxLtncy() const { 
+  #ifdef __HIP_DEVICE_COMPILE__
+  int max = 0;
+  for (int i = 0; i < scsrCnt_; i++) {
+    if (latencies_[i] > max) {
+      max = latencies_[i];
+    }
+  }
+  #else  
+  return GetMaxEdgeLabel();
+  #endif
+  }
 
 __host__ __device__
 int16_t SchedInstruction::GetLastUseCnt() { 
@@ -443,11 +468,11 @@ int16_t SchedInstruction::GetLastUseCnt() {
 #endif
 }
 
-__host__ __device__
+__host__
 SchedInstruction *SchedInstruction::GetFrstPrdcsr(InstCount *scsrNum,
                                                   UDT_GLABEL *ltncy,
                                                   DependenceType *depType,
-						  InstCount *toNodeNum) {
+						                                      InstCount *toNodeNum) {
   GraphEdge *edge = GetFrstPrdcsrEdge();
   if (!edge)
     return NULL;
@@ -462,11 +487,11 @@ SchedInstruction *SchedInstruction::GetFrstPrdcsr(InstCount *scsrNum,
   return (SchedInstruction *)(nodes_[edge->from]);
 }
 
-__host__ __device__
+__host__
 SchedInstruction *SchedInstruction::GetNxtPrdcsr(InstCount *scsrNum,
                                                  UDT_GLABEL *ltncy,
                                                  DependenceType *depType,
-						 InstCount *toNodeNum) {
+						                                     InstCount *toNodeNum) {
   GraphEdge *edge = GetNxtPrdcsrEdge();
   if (!edge)
     return NULL;
@@ -481,11 +506,38 @@ SchedInstruction *SchedInstruction::GetNxtPrdcsr(InstCount *scsrNum,
   return (SchedInstruction *)(nodes_[edge->from]);
 }
 
+__device__
+int SchedInstruction::GetScsrCnt_() {
+  return scsrCnt_;
+}
+
 __host__ __device__
+SchedInstruction *SchedInstruction::GetScsr(int scsrNum, 
+                                            InstCount *prdcsrNum, 
+                                            UDT_GLABEL *ltncy,
+                                            InstCount *scsrNodeNum) {
+  if (scsrNum >= scsrCnt_) {
+    return NULL;
+  } 
+
+  if (prdcsrNum) {
+    *prdcsrNum = predOrder_[scsrNum];
+  }
+  if (ltncy) {
+    *ltncy = latencies_[scsrNum];
+  }
+  if (scsrNodeNum) {
+    *scsrNodeNum = scsrs_[scsrNum];
+  }
+  return (SchedInstruction *) nodes_[scsrs_[scsrNum]];
+
+}
+
+__host__
 SchedInstruction *SchedInstruction::GetFrstScsr(InstCount *prdcsrNum,
                                                 UDT_GLABEL *ltncy,
                                                 DependenceType *depType,
-						InstCount *toNodeNum,
+						                                    InstCount *toNodeNum,
                                                 bool *IsArtificial) {
   GraphEdge *edge = GetFrstScsrEdge();
   if (!edge)
@@ -503,11 +555,11 @@ SchedInstruction *SchedInstruction::GetFrstScsr(InstCount *prdcsrNum,
   return (SchedInstruction *)(nodes_[edge->to]);
 }
 
-__host__ __device__
+__host__
 SchedInstruction *SchedInstruction::GetNxtScsr(InstCount *prdcsrNum,
                                                UDT_GLABEL *ltncy,
                                                DependenceType *depType,
-					       InstCount *toNodeNum,
+					                                     InstCount *toNodeNum,
                                                bool *IsArtificial) {
   GraphEdge *edge = GetNxtScsrEdge();
   if (!edge)
@@ -525,7 +577,7 @@ SchedInstruction *SchedInstruction::GetNxtScsr(InstCount *prdcsrNum,
   return (SchedInstruction *)(nodes_[edge->to]);
 }
 
-__host__ __device__
+__host__
 SchedInstruction *SchedInstruction::GetLastScsr(InstCount *prdcsrNum) {
   GraphEdge *edge = GetLastScsrEdge();
   if (!edge)
@@ -535,7 +587,7 @@ SchedInstruction *SchedInstruction::GetLastScsr(InstCount *prdcsrNum) {
   return (SchedInstruction *)(nodes_[edge->to]);
 }
 
-__host__ __device__
+__host__
 SchedInstruction *SchedInstruction::GetPrevScsr(InstCount *prdcsrNum) {
   GraphEdge *edge = GetPrevScsrEdge();
   if (!edge)
@@ -545,7 +597,7 @@ SchedInstruction *SchedInstruction::GetPrevScsr(InstCount *prdcsrNum) {
   return (SchedInstruction *)(nodes_[edge->to]);
 }
 
-__host__ __device__
+__host__
 SchedInstruction *SchedInstruction::GetFrstNghbr(DIRECTION dir,
                                                  UDT_GLABEL *ltncy) {
   GraphEdge *edge = dir == DIR_FRWRD ? GetFrstScsrEdge() : GetFrstPrdcsrEdge();
@@ -557,7 +609,7 @@ SchedInstruction *SchedInstruction::GetFrstNghbr(DIRECTION dir,
 	  ((dir == DIR_FRWRD) ? nodes_[edge->to] : nodes_[edge->from]);
 }
 
-__host__ __device__
+__host__
 SchedInstruction *SchedInstruction::GetNxtNghbr(DIRECTION dir,
                                                 UDT_GLABEL *ltncy) {
   GraphEdge *edge = dir == DIR_FRWRD ? GetNxtScsrEdge() : GetNxtPrdcsrEdge();
@@ -569,27 +621,26 @@ SchedInstruction *SchedInstruction::GetNxtNghbr(DIRECTION dir,
 	  ((dir == DIR_FRWRD) ? nodes_[edge->to] : nodes_[edge->from]);
 }
 
-__host__ __device__
+__host__
 InstCount SchedInstruction::CmputCrtclPathFrmRoot() {
   crtclPathFrmRoot_ = CmputCrtclPath_(DIR_FRWRD);
   return crtclPathFrmRoot_;
 }
 
-__host__ __device__
+__host__
 InstCount SchedInstruction::CmputCrtclPathFrmLeaf() {
   crtclPathFrmLeaf_ = CmputCrtclPath_(DIR_BKWRD);
   return crtclPathFrmLeaf_;
 }
 
-__host__ __device__
-InstCount
-SchedInstruction::CmputCrtclPathFrmRcrsvPrdcsr(SchedInstruction *ref) {
+__host__
+InstCount SchedInstruction::CmputCrtclPathFrmRcrsvPrdcsr(SchedInstruction *ref) {
   InstCount refInstNum = ref->GetNum();
   crtclPathFrmRcrsvPrdcsr_[refInstNum] = CmputCrtclPath_(DIR_FRWRD, ref);
   return crtclPathFrmRcrsvPrdcsr_[refInstNum];
 }
 
-__host__ __device__
+__host__
 InstCount SchedInstruction::CmputCrtclPathFrmRcrsvScsr(SchedInstruction *ref) {
   InstCount refInstNum = ref->GetNum();
   crtclPathFrmRcrsvScsr_[refInstNum] = CmputCrtclPath_(DIR_BKWRD, ref);
@@ -841,7 +892,7 @@ void SchedInstruction::UnSchedule() {
   crntSchedSlot_ = SCHD_UNSCHDULD;
 }
 
-__host__ __device__
+__host__
 void SchedInstruction::UnTightnLwrBounds() { crntRange_->UnTightnLwrBounds(); }
 
 __host__ __device__
@@ -867,7 +918,7 @@ bool SchedInstruction::IsFxd() const { return crntRange_->IsFxd(); }
 __host__ __device__
 InstCount SchedInstruction::GetPreFxdCycle() const { return preFxdCycle_; }
 
-__host__ __device__
+__host__
 bool SchedInstruction::TightnLwrBound(DIRECTION dir, InstCount newLwrBound,
                                       LinkedList<SchedInstruction> *tightndLst,
                                       LinkedList<SchedInstruction> *fxdLst,
@@ -876,7 +927,7 @@ bool SchedInstruction::TightnLwrBound(DIRECTION dir, InstCount newLwrBound,
                                     enforce);
 }
 
-__host__ __device__
+__host__
 bool SchedInstruction::TightnLwrBoundRcrsvly(
     DIRECTION dir, InstCount newLwrBound,
     LinkedList<SchedInstruction> *tightndLst,
@@ -885,7 +936,7 @@ bool SchedInstruction::TightnLwrBoundRcrsvly(
                                            enforce);
 }
 
-__host__ __device__
+__host__
 bool SchedInstruction::ProbeScsrsCrntLwrBounds(InstCount cycle) {
   if (cycle <= crntRange_->GetLwrBound(DIR_FRWRD))
     return false;
@@ -936,7 +987,7 @@ InstCount SchedInstruction::GetFileLB() const {
   return fileLwrBound_;
 }
 
-__host__ __device__
+__host__
 void SchedInstruction::SetScsrNums_() {
   InstCount scsrNum = 0;
 
@@ -948,7 +999,7 @@ void SchedInstruction::SetScsrNums_() {
   assert(scsrNum == GetScsrCnt());
 }
 
-__host__ __device__
+__host__
 void SchedInstruction::SetPrdcsrNums_() {
   InstCount prdcsrNum = 0;
 
@@ -1060,6 +1111,32 @@ void SchedInstruction::InitializeNode_(InstCount instNum,
   GraphNode::SetNum(instNum);
 }
 
+// Preprocessing necessary to avoid GraphEdges on device.
+__host__
+void SchedInstruction::SetupForDevice() {
+  int prdcsrNum, latency, toNodeNum;
+  DependenceType _dep; // Not used here.
+  int _numScsrs = GetScsrCnt();
+  
+  scsrs_ = new int[_numScsrs];
+  latencies_ = new int[_numScsrs];
+  predOrder_ = new int[_numScsrs];
+
+  int i = 0;
+
+  for (SchedInstruction *crntScsr = GetFrstScsr(&prdcsrNum, 
+                                                &latency,
+                                                &_dep, 
+                                                &toNodeNum);
+       crntScsr != NULL; 
+       crntScsr = GetNxtScsr(&prdcsrNum, &latency, &_dep, &toNodeNum)) {
+         scsrs_[i] = toNodeNum;
+         latencies_[i] = latency;
+         predOrder_[i++] = prdcsrNum;
+       }
+}
+
+// TODO(bruce) fix method signature
 void SchedInstruction::CopyPointersToDevice(SchedInstruction *dev_inst,
                                             GraphNode **dev_nodes,
 					                                  InstCount instCnt, 
@@ -1072,18 +1149,32 @@ void SchedInstruction::CopyPointersToDevice(SchedInstruction *dev_inst,
                                             int &scsrIndex,
                                             InstCount *dev_ltncyPerPrdcsr,
                                             int &ltncyIndex) {
-  dev_inst->RegFiles_ = dev_regFiles;
+  SetupForDevice();
   size_t memSize;
+  memSize = sizeof(InstCount) * scsrCnt_;
+  if (memSize) {
+    gpuErrchk(hipMallocManaged(&(dev_inst->scsrs_), memSize));
+    gpuErrchk(hipMallocManaged(&(dev_inst->latencies_), memSize));
+    gpuErrchk(hipMallocManaged(&(dev_inst->predOrder_), memSize));
+	
+    gpuErrchk(hipMemcpy(dev_inst->scsrs_, scsrs_, memSize, hipMemcpyHostToDevice));
+    gpuErrchk(hipMemcpy(dev_inst->latencies_, latencies_, memSize, hipMemcpyHostToDevice));
+    gpuErrchk(hipMemcpy(dev_inst->predOrder_, predOrder_, memSize, hipMemcpyHostToDevice));
+
+  }
+  // Make sure instruction knows whether it's a leaf on device for legality checking.
+  dev_inst->SetDevIsLeaf(scsrCnt_ == 0);
+  dev_inst->RegFiles_ = dev_regFiles;
   dev_inst->ltncyPerPrdcsr_ = &dev_ltncyPerPrdcsr[ltncyIndex];
   for (InstCount i = 0; i < prdcsrCnt_; i++) {
     dev_inst->ltncyPerPrdcsr_[i] = ltncyPerPrdcsr_[i];
   }
   ltncyIndex += prdcsrCnt_;
 
-  // Copy sortedScsrLst_
   GraphNode::CopyPointersToDevice((GraphNode *)dev_inst, dev_nodes, instCnt,
                                   edges, dev_edges, dev_scsrElmnts, 
                                   dev_keys, scsrIndex);
+  
   // make sure managed mem is copied to device before kernel start
   memSize = sizeof(InstCount *) * numThreads;
   gpuErrchk(hipMemPrefetchAsync(dev_rdyCyclePerPrdcsr_, memSize, 0));
@@ -1105,8 +1196,12 @@ void SchedInstruction::FreeDevicePointers(int numThreads) {
     hipFree(rcrsvScsrLst_->dev_crnt_);
   if (rcrsvPrdcsrLst_)
     hipFree(rcrsvPrdcsrLst_->dev_crnt_);
-  hipFree(scsrLst_->dev_crnt_);
-  GraphNode::FreeDevicePointers();
+
+  if (scsrCnt_ > 0) { 
+    hipFree(scsrs_);
+    hipFree(latencies_);
+    hipFree(predOrder_);
+  }
 }
 
 void SchedInstruction::AllocDevArraysForParallelACO(int numThreads) {
@@ -1143,18 +1238,6 @@ void SchedInstruction::AllocDevArraysForParallelACO(int numThreads) {
   for (int i = 0; i < numThreads; i++) {
     dev_rdyCyclePerPrdcsr_[i] = &temp_arr[i * prdcsrCnt_];
   }
-  // Alloc arrays of iterators for each array list
-  // Alloc array of iterators for sortedScsrLst_
-  memSize = sizeof(int) * numThreads;
-  if (sortedScsrLst_)  
-    gpuErrchk(hipMalloc(&sortedScsrLst_->dev_crnt_, memSize));
-  if (sortedPrdcsrLst_)
-    gpuErrchk(hipMalloc(&sortedPrdcsrLst_->dev_crnt_, memSize));
-  if (rcrsvScsrLst_)
-    gpuErrchk(hipMalloc(&rcrsvScsrLst_->dev_crnt_, memSize));
-  if (rcrsvPrdcsrLst_)
-    gpuErrchk(hipMalloc(&rcrsvPrdcsrLst_->dev_crnt_, memSize));
-  gpuErrchk(hipMalloc(&scsrLst_->dev_crnt_, memSize));
 }
 
 /******************************************************************************
@@ -1170,7 +1253,7 @@ SchedRange::SchedRange(SchedInstruction *inst) {
   lastCycle_ = INVALID_VALUE;
 }
 
-__host__ __device__
+__host__
 bool SchedRange::TightnLwrBound(DIRECTION dir, InstCount newBound,
                                 LinkedList<SchedInstruction> *tightndLst,
                                 LinkedList<SchedInstruction> *fxdLst,
@@ -1222,7 +1305,7 @@ bool SchedRange::TightnLwrBound(DIRECTION dir, InstCount newBound,
   return fsbl;
 }
 
-__host__ __device__
+__host__
 bool SchedRange::TightnLwrBoundRcrsvly(DIRECTION dir, InstCount newBound,
                                        LinkedList<SchedInstruction> *tightndLst,
                                        LinkedList<SchedInstruction> *fxdLst,
@@ -1268,7 +1351,7 @@ bool SchedRange::TightnLwrBoundRcrsvly(DIRECTION dir, InstCount newBound,
   return fsbl;
 }
 
-__host__ __device__
+__host__
 bool SchedRange::Fix(InstCount cycle, LinkedList<SchedInstruction> *tightndLst,
                      LinkedList<SchedInstruction> *fxdLst) {
   if (cycle < frwrdLwrBound_ || cycle > GetDeadline())
@@ -1341,7 +1424,7 @@ InstCount SchedRange::GetDeadline() const {
 __host__ __device__
 bool SchedRange::IsFsbl_() const { return GetLwrBoundSum_() <= lastCycle_; }
 
-__host__ __device__
+__host__
 void SchedRange::UnTightnLwrBounds() {
   assert(IsFsbl_());
   assert(isFrwrdTightnd_ || isBkwrdTightnd_);


### PR DESCRIPTION
Summary of changes:
  * Information about successors is consolidated into scsrs_, latencies_, predOrder_ for instructions being sent to device.
  * Removed __device__ flag from many functions relying on the use of GraphEdge objects.
  * Added some GraphNode functionality to SchedInstruction for use on the device:
    * SchedInstruction::GetScsr() used in place of GraphNode::GetFrstScsr()/GetNxtScsr()
    * SchedInstruction::GetScsrCnt_() used in place of GraphNode::GetScsrCnt()
  * GraphNode::IsLeaf() returns the value of dev_IsLeaf when called on the device.
  * ACO scheduler and the list scheduler use the new SchedInstruction methods to traverse successors when on the device.