### PR TITLE
HIP_ACO successor list batching

### DIFF
--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -117,6 +117,7 @@ private:
                               bool closeToRPTarget, bool currentlyWaiting);
   __host__ __device__
   void UpdateACOReadyList(SchedInstruction *Inst);
+
   DeviceVector<pheromone_t> pheromone_;
   // new ds representations
   ACOReadyList *readyLs;

--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -346,6 +346,11 @@ public:
   Register *getRegByTuple(RegIndxTuple *tuple) { 
     return RegFiles[tuple->regType_].GetReg(tuple->regNum_); 
   }
+
+  int* scsrs_;
+  int* latencies_;
+  int* predOrder_;
+
   // Deep Copies DDG's arrays to device and links them to device DDG pointer
   void CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads = 0);
   // Calls hipFree on all arrays/objects that were allocated with hipMalloc

--- a/include/opt-sched/Scheduler/gen_sched.h
+++ b/include/opt-sched/Scheduler/gen_sched.h
@@ -117,6 +117,13 @@ public:
   __host__
   virtual ~ConstrainedScheduler();
 
+  __device__
+  SchedInstruction *GetScsr(SchedInstruction* inst,
+                            int scsrNum, 
+                            InstCount *prdcsrNum = NULL, 
+                            UDT_GLABEL *ltncy = NULL, 
+                            InstCount *scsrNodeNum = NULL);
+
   // Calculates the schedule and returns it in the passed argument.
   //__host__ __device__
   //FUNC_RESULT FindSchedule(InstSchedule *sched, SchedRegion *rgn) = 0;

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -562,21 +562,9 @@ public:
 
   friend class SchedRange;
 
-  // array of nodes_ indices referring to this instruction's successors.
-  int* scsrs_;
-  // array of latencies of this instruction's successors.
-  int* latencies_;
-  // array of this instruction's order in the predecessor lists of each of its successors.
-  int* predOrder_;
-
-  // Returns the successor of this instruction node given by the scsrNum
-  // (its index in scsrs_). Fills prdcsrNum, ltncy, and scsrNodeNum (the
-  // instruction's index in nodes_) if provided.
-  __host__ __device__
-  SchedInstruction *GetScsr(int scsrNum, 
-                            InstCount *prdcsrNum = NULL, 
-                            UDT_GLABEL *ltncy = NULL,
-                            InstCount *scsrNodeNum = NULL);
+  // This instruction's index in the scsrs_, latencies_, predOrder_ arrays
+  // in the DDG.
+  int ddgIndex;
 
   __device__
   int GetScsrCnt_();
@@ -605,6 +593,9 @@ protected:
   InstCount prdcsrCnt_;
   // The number of successors of this instruction.
   InstCount scsrCnt_;
+
+  int dev_maxLatency_;
+  int dev_latencySum_;
 
   // The minimum cycle in which this instruction can be scheduled, given its
   // data and resource constraints.

--- a/lib/Scheduler/aco.hip.cpp
+++ b/lib/Scheduler/aco.hip.cpp
@@ -1569,6 +1569,7 @@ void ACOScheduler::CopyPheromonesToSharedMem(double *s_pheromone) {
     toInstNum += NUMTHREADSPERBLOCK;
   }
 }
+
 __host__ __device__
 inline void ACOScheduler::UpdateACOReadyList(SchedInstruction *inst) {
   InstCount prdcsrNum, scsrRdyCycle;
@@ -1581,8 +1582,8 @@ inline void ACOScheduler::UpdateACOReadyList(SchedInstruction *inst) {
     }
     #endif
     int i = 0;
-    for (SchedInstruction *crntScsr = inst->GetScsr(i++, &prdcsrNum);
-          crntScsr != NULL; crntScsr = inst->GetScsr(i++, &prdcsrNum)) {
+    for (SchedInstruction *crntScsr = GetScsr(inst, i++, &prdcsrNum);
+          crntScsr != NULL; crntScsr = GetScsr(inst, i++, &prdcsrNum)) {
         #ifdef DEBUG_INSTR_SELECTION
         if (GLOBALTID==0) {
           printf(" %d,", crntScsr->GetNum());

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -3727,13 +3727,11 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   predOrder_ = new int[lngthScsrElmnts];
   int indexOffset = 0;
 
-  // Copy SchedInstruction/GraphNode pointers and link them to device inst
-  // and update RegFiles pointer to dev_regFiles
   for (InstCount i = 0; i < instCnt_; i++) {
-    int j = 0;
     DependenceType _dep;
     insts_[i].ddgIndex = indexOffset;
     int prdcsrNum, latency, toNodeNum;
+    // Partition scsrs_, latencies_, predOrder_ for each SchedInstruction.
     for (SchedInstruction *crntScsr = insts_[i].GetFrstScsr(&prdcsrNum, 
                                               &latency,
                                               &_dep, 
@@ -3746,11 +3744,12 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
         indexOffset += 1;
     }
 
+    // Copy SchedInstruction/GraphNode pointers and link them to device inst
+    // and update RegFiles pointer to dev_regFiles
     insts_[i].CopyPointersToDevice(&dev_DDG->insts_[i], dev_DDG->nodes_, 
                                    dev_regFiles, numThreads,
                                    dev_latencies_, latencyIndex);
   }
-  assert(indexOffset == lngthScsrElmnts);
   memSize = sizeof(int) * lngthScsrElmnts;
   gpuErrchk(hipMalloc(&(dev_DDG->scsrs_), memSize));
   gpuErrchk(hipMalloc(&(dev_DDG->latencies_), memSize));

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -3722,12 +3722,44 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   int scsrIndex = 0;
   int latencyIndex = 0;
 
+  scsrs_ = new int[lngthScsrElmnts];
+  latencies_ = new int[lngthScsrElmnts];
+  predOrder_ = new int[lngthScsrElmnts];
+  int indexOffset = 0;
+
   // Copy SchedInstruction/GraphNode pointers and link them to device inst
   // and update RegFiles pointer to dev_regFiles
-  for (InstCount i = 0; i < instCnt_; i++)
+  for (InstCount i = 0; i < instCnt_; i++) {
+    int j = 0;
+    DependenceType _dep;
+    insts_[i].ddgIndex = indexOffset;
+    int prdcsrNum, latency, toNodeNum;
+    for (SchedInstruction *crntScsr = insts_[i].GetFrstScsr(&prdcsrNum, 
+                                              &latency,
+                                              &_dep, 
+                                              &toNodeNum);
+      crntScsr != NULL; 
+      crntScsr = insts_[i].GetNxtScsr(&prdcsrNum, &latency, &_dep, &toNodeNum)) {
+        scsrs_[indexOffset] = toNodeNum;
+        latencies_[indexOffset] = latency;
+        predOrder_[indexOffset] = prdcsrNum;
+        indexOffset += 1;
+    }
+
     insts_[i].CopyPointersToDevice(&dev_DDG->insts_[i], dev_DDG->nodes_, 
                                    dev_regFiles, numThreads,
                                    dev_latencies_, latencyIndex);
+  }
+  assert(indexOffset == lngthScsrElmnts);
+  memSize = sizeof(int) * lngthScsrElmnts;
+  gpuErrchk(hipMalloc(&(dev_DDG->scsrs_), memSize));
+  gpuErrchk(hipMalloc(&(dev_DDG->latencies_), memSize));
+  gpuErrchk(hipMalloc(&(dev_DDG->predOrder_), memSize));
+
+  gpuErrchk(hipMemcpy(dev_DDG->scsrs_, scsrs_, memSize, hipMemcpyHostToDevice));
+  gpuErrchk(hipMemcpy(dev_DDG->latencies_, latencies_, memSize, hipMemcpyHostToDevice));
+  gpuErrchk(hipMemcpy(dev_DDG->predOrder_, predOrder_, memSize, hipMemcpyHostToDevice));
+
   memSize = sizeof(SchedInstruction) * instCnt_;
   gpuErrchk(hipMemPrefetchAsync(dev_insts, memSize, 0));
   memSize = sizeof(RegisterFile) * machMdl_->GetRegTypeCnt();
@@ -3749,6 +3781,9 @@ void DataDepGraph::FreeDevicePointers(int numThreads) {
     insts_[i].FreeDevicePointers(numThreads);
   hipFree(insts_);
   hipFree(nodes_);
+  hipFree(scsrs_);
+  hipFree(latencies_);
+  hipFree(predOrder_);
   // hipFree(dev_latencies_);
   // hipFree(dev_crntRange_);
   // (Josh) These frees are invalid but I am not sure why


### PR DESCRIPTION
Summary of changes:
  * Moved responsibility for getting a particular successor of an instruction to ConstrainedScheduler.
  * Added scsrs_, latencies_, predOrder_ fields to DataDepGraph for use on the device.
  * Removed the corresponding obselete fields from SchedInstruction.