### PR TITLE
HIP_ACO remove graph node

### DIFF
--- a/include/opt-sched/Scheduler/dev_defines.h
+++ b/include/opt-sched/Scheduler/dev_defines.h
@@ -2,6 +2,7 @@
 
 // Formula for determining global thread ID on device
 #define GLOBALTID hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x
+//#define DEBUG_ACO_CRASH_LOCATIONS 0
 
 // Check for and print out errors on CUDA API calls
 #define gpuErrchk(ans) { gpuAssert((ans), __FILE__, __LINE__); }

--- a/include/opt-sched/Scheduler/graph.h
+++ b/include/opt-sched/Scheduler/graph.h
@@ -288,8 +288,6 @@ public:
   __device__
   void Reset();
 
-  // Copy GraphNode arrays/pointers to device
-  void CopyPointersToDevice(GraphNode *dev_node, GraphNode **dev_nodes);
   // Calls hipFree on all arrays/objects that were allocated with hipMalloc
   void FreeDevicePointers();
 

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -553,7 +553,7 @@ public:
                             RegisterFile *dev_regFiles,
                             int numThreads, 
                             InstCount *dev_ltncyPerPrdcsr,
-                            int &ltncyIndex, size_t &totalMemSize);
+                            int &ltncyIndex);
   // Calls hipFree on all arrays/objects that were allocated with hipMalloc
   void FreeDevicePointers(int numThreads);
   // Allocates arrays used for storing individual values for each thread in

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -537,7 +537,7 @@ public:
 		       InstCount maxNodeCnt, int nodeID, 
 		       InstCount fileSchedOrder, InstCount fileSchedCycle, 
 		       InstCount fileLB, InstCount fileUB, MachineModel *model,
-		       GraphNode **nodes, RegisterFile *regFiles);
+		       GraphNode **nodes, SchedInstruction *insts, RegisterFile *regFiles);
   // Creates a new SchedRange for the inst. used after it is copied to device
   __device__
   void CreateSchedRange();
@@ -549,11 +549,11 @@ public:
   // Copies pointers to device and links them to device inst. Also uses
   // the device nodes_ array to set nodes_ in GraphNode
   void CopyPointersToDevice(SchedInstruction *dev_inst,
-                            GraphNode **dev_nodes,
+                            SchedInstruction *dev_instsArray,
                             RegisterFile *dev_regFiles,
                             int numThreads, 
                             InstCount *dev_ltncyPerPrdcsr,
-                            int &ltncyIndex);
+                            int &ltncyIndex, size_t &totalMemSize);
   // Calls hipFree on all arrays/objects that were allocated with hipMalloc
   void FreeDevicePointers(int numThreads);
   // Allocates arrays used for storing individual values for each thread in
@@ -739,6 +739,11 @@ protected:
 
   bool mustBeInBBEntry_;
   bool mustBeInBBExit_;
+
+  // A pointer to the full array of instructions. Needed in order to save
+  // succs/preds and GraphEdge pointers as instNums instead. This allows for
+  // much faster copying to the Device
+  SchedInstruction *insts_;
 
   // TODO(ghassan): Document.
   __host__

--- a/lib/Scheduler/aco.hip.cpp
+++ b/lib/Scheduler/aco.hip.cpp
@@ -228,6 +228,11 @@ InstCount ACOScheduler::SelectInstruction(SchedInstruction *lastInst, InstCount 
                                           SchedRegion *rgn, bool &unnecessarilyStalling,
                                           bool closeToRPTarget, bool currentlyWaiting) {
 #ifdef __HIP_DEVICE_COMPILE__
+  #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("Crash Beginning of SelectInstruction()\n");
+    }
+  #endif
   // if we are waiting and have no fully-ready instruction that is 
   // net 0 or benefit to RP, then return -1 to schedule a stall
   if (currentlyWaiting && dev_RP0OrPositiveCount[GLOBALTID] == 0)
@@ -509,6 +514,11 @@ InstCount ACOScheduler::SelectInstruction(SchedInstruction *lastInst, InstCount 
       unnecessarilyStalling = true;
     else
       unnecessarilyStalling = false;
+  #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("End of SelectInstruction()\n");
+    }
+  #endif
   #else
     if (couldAvoidStalling && *readyLs->getInstReadyOnAtIndex(indx) > crntCycleNum_)
       unnecessarilyStalling = true;
@@ -554,6 +564,11 @@ InstSchedule *ACOScheduler::FindOneSchedule(InstCount RPTarget,
   lastInst = dataDepGraph_->GetInstByIndx(RootId);
   bool closeToRPTarget = false;
   dev_RP0OrPositiveCount[GLOBALTID] = 0;
+  #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("Crash before while loop inside FindOneSchedule()\n");
+    }
+  #endif
   while (!IsSchedComplete_()) {
     // incrementally calculate if there are any instructions with a neutral
     // or positive effect on RP
@@ -588,12 +603,21 @@ InstSchedule *ACOScheduler::FindOneSchedule(InstCount RPTarget,
       #endif
       // select the instruction and get info on it
       InstCount SelIndx = SelectInstruction(lastInst, schedule->getTotalStalls(), dev_rgn_, unnecessarilyStalling, closeToRPTarget, waitFor ? true: false);
-
+      #ifdef DEBUG_ACO_CRASH_LOCATIONS
+        if (hipThreadIdx_x == 0) {
+          printf("After SelectInstruction()\n");
+        }
+      #endif
       if (SelIndx != -1) {
         LastInstInfo = dev_readyLs->removeInstructionAtIndex(SelIndx);
         
         InstCount InstId = LastInstInfo.InstId;
         inst = dataDepGraph_->GetInstByIndx(InstId);
+        #ifdef DEBUG_ACO_CRASH_LOCATIONS
+          if (hipThreadIdx_x == 0) {
+            printf("After Test Print()\n");
+          }
+        #endif
         // potentially wait on the current instruction
         if (LastInstInfo.ReadyOn > crntCycleNum_ || !ChkInstLglty_(inst)) {
           waitUntil = LastInstInfo.ReadyOn;
@@ -664,14 +688,28 @@ InstSchedule *ACOScheduler::FindOneSchedule(InstCount RPTarget,
       DoRsrvSlots_(inst);
       // this is annoying
       UpdtSlotAvlblty_(inst);
-
+      #ifdef DEBUG_ACO_CRASH_LOCATIONS
+        if (hipThreadIdx_x == 0) {
+          printf("Before UpdateACOReadyList()\n");
+        }
+      #endif
       // new readylist update
       UpdateACOReadyList(inst);
+      #ifdef DEBUG_ACO_CRASH_LOCATIONS
+        if (hipThreadIdx_x == 0) {
+          printf("After UpdateACOReadyList()\n");
+        }
+      #endif
     }
     schedule->AppendInst(instNum);
     if (MovToNxtSlot_(inst))
       InitNewCycle_();
   }
+  #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("After while loop inside FindOneSchedule()\n");
+    }
+  #endif
   dev_rgn_->UpdateScheduleCost(schedule);
   schedule->setIsZeroPerp( ((BBWithSpill *)dev_rgn_)->ReturnPeakSpillCost() == 0 );
   return schedule;
@@ -911,6 +949,11 @@ Dev_ACO(SchedRegion *dev_rgn, DataDepGraph *dev_DDG,
             ACOScheduler *dev_AcoSchdulr, InstSchedule **dev_schedules,
             InstSchedule *dev_bestSched, int noImprovementMax, 
             int *blockBestIndex) {
+  #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("Crash very beginning\n");
+    }
+  #endif
   // holds cost and index of bestSched per block
   __shared__ int bestIndex;
   int dev_iterations;
@@ -937,27 +980,51 @@ Dev_ACO(SchedRegion *dev_rgn, DataDepGraph *dev_DDG,
   else
     RPTarget = INT_MAX;
 
+  #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("Crash before while loop\n");
+    }
+  #endif
   // Start ACO
   while (dev_noImprovement < noImprovementMax && !lowerBoundSchedFound) {
     // Reset schedules to post constructor state
     dev_schedules[GLOBALTID]->Initialize();
+    #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("Before FindOneSchedule() loop\n");
+    }
+    #endif
     dev_AcoSchdulr->FindOneSchedule(RPTarget,
                                     dev_schedules[GLOBALTID]);
     // Sync threads after schedule creation
     threadGroup.sync();
+    #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("After FindOneSchedule()\n");
+    }
+    #endif
     globalBestIndex = INVALID_VALUE;
     // reduce dev_schedules to 1 best schedule per block
     if (GLOBALTID < dev_AcoSchdulr->GetNumThreads()/2)
       reduceToBestSchedPerBlock(dev_schedules, blockBestIndex, dev_AcoSchdulr, RPTarget);
 
     threadGroup.sync();
-
+    #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("After reduceToBestSchedPerBlock() loop\n");
+    }
+    #endif
     // one block to reduce blockBest schedules to one best schedule
     if (hipBlockIdx_x == 0)
       reduceToBestSched(dev_schedules, blockBestIndex, dev_AcoSchdulr, dev_AcoSchdulr->GetNumBlocks(), RPTarget);
 
-    threadGroup.sync();    
+    threadGroup.sync();
 
+    #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("After reduceToBestSched() loop\n");
+    }
+    #endif
     if (GLOBALTID == 0 && 
         dev_schedules[blockBestIndex[0]]->GetCost() != INVALID_VALUE)
       globalBestIndex = blockBestIndex[0];
@@ -1021,6 +1088,11 @@ Dev_ACO(SchedRegion *dev_rgn, DataDepGraph *dev_DDG,
         if (dev_noImprovement > noImprovementMax)
           break;
       }
+      #ifdef DEBUG_ACO_CRASH_LOCATIONS
+        if (hipThreadIdx_x == 0) {
+          printf("After Global TID 0 selects best schedule\n");
+        }
+      #endif
     }
     // perform pheremone update based on selected scheme
 #if (PHER_UPDATE_SCHEME == ONE_PER_ITER)
@@ -1066,9 +1138,19 @@ Dev_ACO(SchedRegion *dev_rgn, DataDepGraph *dev_DDG,
     }
   #endif
     threadGroup.sync();
+    #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("After UpdatePheromone() loop\n");
+    }
+    #endif
     dev_AcoSchdulr->ScalePheromoneTable();
     // wait for other blocks to finish before starting next iteration
     threadGroup.sync();
+    #ifdef DEBUG_ACO_CRASH_LOCATIONS
+    if (hipThreadIdx_x == 0) {
+      printf("After ScalePheromoneTable() loop\n");
+    }
+    #endif
     // make sure no threads reset schedule before above operations complete
     dev_schedules[GLOBALTID]->resetTotalStalls();
     dev_schedules[GLOBALTID]->resetUnnecessaryStalls();
@@ -1579,6 +1661,11 @@ inline void ACOScheduler::UpdateACOReadyList(SchedInstruction *inst) {
     if (GLOBALTID==0) {
       printf("successors of %d:", inst->GetNum());
     }
+    #endif
+    #ifdef DEBUG_ACO_CRASH_LOCATIONS
+      if (hipThreadIdx_x == 0) {
+        printf("Before for loop inside UpdateACOReadyList()\n");
+      }
     #endif
     int i = 0;
     for (SchedInstruction *crntScsr = inst->GetScsr(i++, &prdcsrNum);

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -3701,7 +3701,7 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   for (InstCount i = 0; i < instCnt_; i++)
     insts_[i].CopyPointersToDevice(&dev_DDG->insts_[i], dev_DDG->insts_,
                                    dev_regFiles, numThreads,
-                                   dev_latencies_, latencyIndex, totalMemSize);
+                                   dev_latencies_, latencyIndex);
   memSize = sizeof(SchedInstruction) * instCnt_;
   gpuErrchk(hipMemPrefetchAsync(dev_insts, memSize, 0));
   memSize = sizeof(RegisterFile) * machMdl_->GetRegTypeCnt();

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -914,7 +914,7 @@ SchedInstruction *DataDepGraph::CreateNode_(
   insts_[instNum].InitializeNode_(instNum, instName, instType, opCode,
                                   2 * instCnt_, nodeID, fileSchedOrder,
                                   fileSchedCycle, fileLB, fileUB, machMdl_,
-				  nodes_, RegFiles);
+				  nodes_, insts_, RegFiles);
 
   if ((instNum < 0 || instNum >= instCnt_) && instNum != UNINITIATED_NUM)
     printf("Invalid instruction number\n");
@@ -996,14 +996,14 @@ void DataDepGraph::CreateEdge_(InstCount frmNodeNum, InstCount toNodeNum,
   GraphEdge *edge;
 
   assert(frmNodeNum < instCnt_);
-  assert(nodes_[frmNodeNum] != NULL);
+  assert(insts_ + frmNodeNum != NULL);
 
   assert(toNodeNum < instCnt_);
 
-  assert(nodes_[toNodeNum] != NULL);
+  assert(insts_ + toNodeNum != NULL);
 
-  GraphNode *frmNode = nodes_[frmNodeNum];
-  GraphNode *toNode = nodes_[toNodeNum];
+  GraphNode *frmNode = insts_ + frmNodeNum;
+  GraphNode *toNode = insts_ +toNodeNum;
   
 #ifdef IS_DEBUG_LATENCIES
   stats::dependenceTypeLatencies.Add(GetDependenceTypeName(depType), ltncy);
@@ -3668,31 +3668,6 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   SchedInstruction *dev_leaf = &dev_insts[leaf_->GetNum()];
   gpuErrchk(hipMemcpy(&dev_DDG->leaf_, &dev_leaf, memSize,
 	               hipMemcpyHostToDevice));
-  // Copy nodes_ to device
-  SchedInstruction **dev_nodes;
-  memSize = sizeof(SchedInstruction *) * instCnt_;
-  gpuErrchk(hipMallocManaged(&dev_nodes, memSize));
-  gpuErrchk(hipMemcpy(dev_nodes, nodes_, memSize, hipMemcpyHostToDevice));
-  gpuErrchk(hipMemcpy(&dev_DDG->nodes_, &dev_nodes,
-		       sizeof(SchedInstruction **),
-	  	       hipMemcpyHostToDevice));
-  // update nodes_ values on device
-  for (InstCount i = 0; i < instCnt_; i++) 
-    dev_DDG->nodes_[i] = &dev_insts[i];
-  gpuErrchk(hipMemPrefetchAsync(dev_DDG->nodes_, memSize, 0));
-  // Copy tplgclOrdr_ to device
-  SchedInstruction **dev_tplgclOrdr;
-  memSize = sizeof(SchedInstruction *) * instCnt_;
-  gpuErrchk(hipMallocManaged(&dev_tplgclOrdr, memSize));
-  gpuErrchk(hipMemcpy(dev_tplgclOrdr, tplgclOrdr_, memSize,
-                       hipMemcpyHostToDevice));
-  gpuErrchk(hipMemcpy(&dev_DDG->tplgclOrdr_, &dev_tplgclOrdr,
-                       sizeof(SchedInstruction **),
-                       hipMemcpyHostToDevice));
-  // update tplgclOrdr values on device
-  for (InstCount i = 0; i < instCnt_; i++) 
-    dev_DDG->tplgclOrdr_[i] = &dev_insts[tplgclOrdr_[i]->GetNum()];
-  gpuErrchk(hipMemPrefetchAsync(dev_DDG->tplgclOrdr_, memSize, 0));
   // Copy RegFiles
   RegisterFile *dev_regFiles;
   memSize = sizeof(RegisterFile) * machMdl_->GetRegTypeCnt();
@@ -3721,13 +3696,12 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
 
   int scsrIndex = 0;
   int latencyIndex = 0;
-
   // Copy SchedInstruction/GraphNode pointers and link them to device inst
   // and update RegFiles pointer to dev_regFiles
   for (InstCount i = 0; i < instCnt_; i++)
-    insts_[i].CopyPointersToDevice(&dev_DDG->insts_[i], dev_DDG->nodes_, 
+    insts_[i].CopyPointersToDevice(&dev_DDG->insts_[i], dev_DDG->insts_,
                                    dev_regFiles, numThreads,
-                                   dev_latencies_, latencyIndex);
+                                   dev_latencies_, latencyIndex, totalMemSize);
   memSize = sizeof(SchedInstruction) * instCnt_;
   gpuErrchk(hipMemPrefetchAsync(dev_insts, memSize, 0));
   memSize = sizeof(RegisterFile) * machMdl_->GetRegTypeCnt();
@@ -3748,7 +3722,6 @@ void DataDepGraph::FreeDevicePointers(int numThreads) {
   for (InstCount i = 0; i < instCnt_; i++)
     insts_[i].FreeDevicePointers(numThreads);
   hipFree(insts_);
-  hipFree(nodes_);
   // hipFree(dev_latencies_);
   // hipFree(dev_crntRange_);
   // (Josh) These frees are invalid but I am not sure why

--- a/lib/Scheduler/graph.hip.cpp
+++ b/lib/Scheduler/graph.hip.cpp
@@ -376,11 +376,6 @@ int compareGEptr(const void * a, const void * b) {
     return 0;
 }
 
-void GraphNode::CopyPointersToDevice(GraphNode *dev_node, 
-                                     GraphNode **dev_nodes) {  
-  //set value of nodes_ to dev_insts_
-  dev_node->nodes_ = dev_nodes;
-}
 
 void GraphNode::FreeDevicePointers() {
   if (scsrLst_)

--- a/lib/Scheduler/sched_basic_data.hip.cpp
+++ b/lib/Scheduler/sched_basic_data.hip.cpp
@@ -1106,7 +1106,7 @@ void SchedInstruction::CopyPointersToDevice(SchedInstruction *dev_inst,
 					                                  RegisterFile *dev_regFiles,
                                             int numThreads, 
                                             InstCount *dev_ltncyPerPrdcsr,
-                                            int &ltncyIndex, size_t &totalMemSize) {
+                                            int &ltncyIndex) {
   SetupForDevice();
   size_t memSize;
   memSize = sizeof(InstCount) * scsrCnt_;
@@ -1120,7 +1120,6 @@ void SchedInstruction::CopyPointersToDevice(SchedInstruction *dev_inst,
     gpuErrchk(hipMemcpy(dev_inst->predOrder_, predOrder_, memSize, hipMemcpyHostToDevice));
 
   }
-  totalMemSize += memSize*3;
   // Make sure instruction knows whether it's a leaf on device for legality checking.
   dev_inst->SetDevIsLeaf(scsrCnt_ == 0);
   dev_inst->RegFiles_ = dev_regFiles;


### PR DESCRIPTION
- Remove the usage of GraphNode functions and the nodes_ array on the device
- Add some debug print statements in ACO, usable through defining DEBUG_ACO_CRASH_LOCATIONS