### PR TITLE
HIP_ACO smaller SchedInstruction & flattened arrays

### DIFF
--- a/include/opt-sched/Scheduler/bb_spill.h
+++ b/include/opt-sched/Scheduler/bb_spill.h
@@ -9,6 +9,10 @@ Last Update:  Apr. 2011
 #ifndef OPTSCHED_SPILL_BB_SPILL_H
 #define OPTSCHED_SPILL_BB_SPILL_H
 
+#ifndef NUMTHREADS
+#define NUMTHREADS hipBlockDim_x * hipGridDim_x
+#endif
+
 #include "opt-sched/Scheduler/OptSchedTarget.h"
 #include "opt-sched/Scheduler/defines.h"
 #include "opt-sched/Scheduler/sched_region.h"
@@ -68,7 +72,7 @@ private:
   int *sumOfLiveIntervalLengths_;
   // pointer to a device array used to store sumOfLiveIntervalLengths_ for
   // each thread by parallel ACO
-  int **dev_sumOfLiveIntervalLengths_;
+  int *dev_sumOfLiveIntervalLengths_;
 
   InstCount staticSlilLowerBound_ = 0;
 
@@ -242,7 +246,7 @@ public:
   __host__ __device__
   bool IsRPHigh(int regType) const {
     #ifdef __HIP_DEVICE_COMPILE__
-    return dev_regPressures_[GLOBALTID*regTypeCnt_+regType] > (unsigned int) machMdl_->GetPhysRegCnt(regType);
+    return dev_regPressures_[regType*NUMTHREADS+GLOBALTID] > (unsigned int) machMdl_->GetPhysRegCnt(regType);
     #else
       return regPressures_[regType] > (unsigned int) machMdl_->GetPhysRegCnt(regType);
     #endif

--- a/include/opt-sched/Scheduler/bb_spill.h
+++ b/include/opt-sched/Scheduler/bb_spill.h
@@ -72,6 +72,7 @@ private:
   int *sumOfLiveIntervalLengths_;
   // pointer to a device array used to store sumOfLiveIntervalLengths_ for
   // each thread by parallel ACO
+  // Indexed by register type * NUMTHREADS + GLOBALTID
   int *dev_sumOfLiveIntervalLengths_;
 
   InstCount staticSlilLowerBound_ = 0;
@@ -102,15 +103,18 @@ private:
   InstCount *spillCosts_;
   // pointer to a device array used to store spillCosts_ for
   // each thread by parallel ACO
+  // Indexed by instruction number * NUMTHREADS + GLOBALTID
   InstCount *dev_spillCosts_;
   // Current register pressure for each register type.
   SmallVector<unsigned, 8> regPressures_;
   // pointer to a device array used to store regPressures_ for
   // each thread by parallel ACO
+  // Indexed by register type * NUMTHREADS + GLOBALTID
   unsigned *dev_regPressures_;
   InstCount *peakRegPressures_;
   // pointer to a device array used to store peakRegPressures_ for
   // each thread by parallel ACO
+  // Indexed by register type * NUMTHREADS + GLOBALTID
   InstCount *dev_peakRegPressures_;
 
   InstCount crntStepNum_;

--- a/include/opt-sched/Scheduler/bb_spill.h
+++ b/include/opt-sched/Scheduler/bb_spill.h
@@ -98,7 +98,7 @@ private:
   InstCount *spillCosts_;
   // pointer to a device array used to store spillCosts_ for
   // each thread by parallel ACO
-  InstCount **dev_spillCosts_;
+  InstCount *dev_spillCosts_;
   // Current register pressure for each register type.
   SmallVector<unsigned, 8> regPressures_;
   // pointer to a device array used to store regPressures_ for

--- a/include/opt-sched/Scheduler/bb_spill.h
+++ b/include/opt-sched/Scheduler/bb_spill.h
@@ -9,10 +9,6 @@ Last Update:  Apr. 2011
 #ifndef OPTSCHED_SPILL_BB_SPILL_H
 #define OPTSCHED_SPILL_BB_SPILL_H
 
-#ifndef NUMTHREADS
-#define NUMTHREADS hipBlockDim_x * hipGridDim_x
-#endif
-
 #include "opt-sched/Scheduler/OptSchedTarget.h"
 #include "opt-sched/Scheduler/defines.h"
 #include "opt-sched/Scheduler/sched_region.h"
@@ -52,6 +48,9 @@ private:
 
   int16_t regTypeCnt_;
   RegisterFile *regFiles_;
+
+  // Number of threads used by parallel ACO.
+  int numThreads_;
 
   // A bit vector indexed by register number indicating whether that
   // register is live

--- a/include/opt-sched/Scheduler/bb_spill.h
+++ b/include/opt-sched/Scheduler/bb_spill.h
@@ -107,7 +107,7 @@ private:
   InstCount *peakRegPressures_;
   // pointer to a device array used to store peakRegPressures_ for
   // each thread by parallel ACO
-  InstCount **dev_peakRegPressures_;
+  InstCount *dev_peakRegPressures_;
 
   InstCount crntStepNum_;
   // pointer to a device array used to store crntStepNum_ for

--- a/include/opt-sched/Scheduler/bb_spill.h
+++ b/include/opt-sched/Scheduler/bb_spill.h
@@ -103,7 +103,7 @@ private:
   SmallVector<unsigned, 8> regPressures_;
   // pointer to a device array used to store regPressures_ for
   // each thread by parallel ACO
-  unsigned **dev_regPressures_;
+  unsigned *dev_regPressures_;
   InstCount *peakRegPressures_;
   // pointer to a device array used to store peakRegPressures_ for
   // each thread by parallel ACO
@@ -242,7 +242,7 @@ public:
   __host__ __device__
   bool IsRPHigh(int regType) const {
     #ifdef __HIP_DEVICE_COMPILE__
-    return dev_regPressures_[regType][GLOBALTID] > (unsigned int) machMdl_->GetPhysRegCnt(regType);
+    return dev_regPressures_[GLOBALTID*regTypeCnt_+regType] > (unsigned int) machMdl_->GetPhysRegCnt(regType);
     #else
       return regPressures_[regType] > (unsigned int) machMdl_->GetPhysRegCnt(regType);
     #endif

--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -823,7 +823,7 @@ public:
   void SetPeakRegPressures(InstCount *regPressures);
   // Device version of PeakRegPressures
   __device__
-  void Dev_SetPeakRegPressures(InstCount **regPressures);
+  void Dev_SetPeakRegPressures(InstCount *regPressures);
   InstCount GetPeakRegPressures(const InstCount *&regPressures) const;
   __host__ __device__
   InstCount GetSpillCost(InstCount stepNum);

--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -818,7 +818,7 @@ public:
   void SetSpillCosts(InstCount *spillCosts);
   // Device version of set spill costs
   __device__
-  void Dev_SetSpillCosts(InstCount **spillCosts);
+  void Dev_SetSpillCosts(InstCount *spillCosts);
   __host__ __device__
   void SetPeakRegPressures(InstCount *regPressures);
   // Device version of PeakRegPressures

--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -199,6 +199,8 @@ public:
   __host__
   virtual ~DataDepGraph();
 
+  void SetNumThreads(int numThreads);
+
   //Prevent DDG from being abstract, these should not actually be invoked
   virtual void convertSUnits(bool IgnoreRealEdges, bool IgnoreArtificialEdges) {
     Logger::Fatal("Wrong convertSUnits called");
@@ -756,6 +758,9 @@ private:
   int totalStalls_, unnecessaryStalls_;
   bool isZeroPerp_;
 
+  // Number of threads used by parallel ACO.
+  int numThreads_;
+
   bool VerifySlots_(MachineModel *machMdl, DataDepGraph *dataDepGraph);
   bool VerifyDataDeps_(DataDepGraph *dataDepGraph);
   __host__ __device__
@@ -867,6 +872,10 @@ public:
   // Copies device arrays to host
   void CopyArraysToHost();
   void FreeDeviceArrays();
+
+  __host__ __device__
+  void SetNumThreads(int numThreads);
+
   // Initializes schedules on device, used between iterations of ACO
   __device__
   void Initialize();

--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -363,6 +363,9 @@ public:
   RegIndxTuple* defs_;
   int* ltncyPerPrdcsr_;
 
+  // Number of threads used by parallel ACO.
+  int numThreads_;
+
   // Tracks all registers in the scheduling region. Each RegisterFile
   // object holds all registers for a given register type.
   RegisterFile *RegFiles;

--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -346,10 +346,21 @@ public:
   Register *getRegByTuple(RegIndxTuple *tuple) { 
     return RegFiles[tuple->regType_].GetReg(tuple->regNum_); 
   }
+  __host__ __device__
+  RegIndxTuple *getUseByIndex(int index) {
+    return uses_ + index;
+  }
+
+  __host__ __device__
+  RegIndxTuple *getDefByIndex(int index) {
+    return defs_ + index;
+  }
 
   int* scsrs_;
   int* latencies_;
   int* predOrder_;
+  RegIndxTuple* uses_;
+  RegIndxTuple* defs_;
   int* ltncyPerPrdcsr_;
 
   // Tracks all registers in the scheduling region. Each RegisterFile

--- a/include/opt-sched/Scheduler/dev_defines.h
+++ b/include/opt-sched/Scheduler/dev_defines.h
@@ -2,6 +2,7 @@
 
 // Formula for determining global thread ID on device
 #define GLOBALTID hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x
+#define NUMTHREADS hipBlockDim_x * hipGridDim_x
 //#define DEBUG_ACO_CRASH_LOCATIONS 0
 
 // Check for and print out errors on CUDA API calls

--- a/include/opt-sched/Scheduler/dev_defines.h
+++ b/include/opt-sched/Scheduler/dev_defines.h
@@ -2,7 +2,6 @@
 
 // Formula for determining global thread ID on device
 #define GLOBALTID hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x
-#define NUMTHREADS hipBlockDim_x * hipGridDim_x
 //#define DEBUG_ACO_CRASH_LOCATIONS 0
 
 // Check for and print out errors on CUDA API calls

--- a/include/opt-sched/Scheduler/gen_sched.h
+++ b/include/opt-sched/Scheduler/gen_sched.h
@@ -187,7 +187,7 @@ protected:
   // pointer to a device array used to store rsrvSlots_ for
   // each thread by parallel ACO
   // TODO(bruce): refactor
-  ReserveSlot **dev_rsrvSlots_;
+  ReserveSlot *dev_rsrvSlots_;
   // The number of elements in rsrvSlots_.
   int16_t rsrvSlotCnt_;
   // pointer to a device array used to store rsrvSlotCnt_ for

--- a/include/opt-sched/Scheduler/gen_sched.h
+++ b/include/opt-sched/Scheduler/gen_sched.h
@@ -179,14 +179,12 @@ protected:
   int16_t *avlblSlotsInCrntCycle_;
   // pointer to a device array used to store avlblSlotsInCrntCycle_ for
   // each thread by parallel ACO
-  // TODO(bruce): refactor
   int16_t *dev_avlblSlotsInCrntCycle_;
 
   // The reserved scheduling slots.
   ReserveSlot *rsrvSlots_;
   // pointer to a device array used to store rsrvSlots_ for
   // each thread by parallel ACO
-  // TODO(bruce): refactor
   ReserveSlot *dev_rsrvSlots_;
   // The number of elements in rsrvSlots_.
   int16_t rsrvSlotCnt_;

--- a/include/opt-sched/Scheduler/gen_sched.h
+++ b/include/opt-sched/Scheduler/gen_sched.h
@@ -179,12 +179,14 @@ protected:
   int16_t *avlblSlotsInCrntCycle_;
   // pointer to a device array used to store avlblSlotsInCrntCycle_ for
   // each thread by parallel ACO
-  int16_t **dev_avlblSlotsInCrntCycle_;
+  // TODO(bruce): refactor
+  int16_t *dev_avlblSlotsInCrntCycle_;
 
   // The reserved scheduling slots.
   ReserveSlot *rsrvSlots_;
   // pointer to a device array used to store rsrvSlots_ for
   // each thread by parallel ACO
+  // TODO(bruce): refactor
   ReserveSlot **dev_rsrvSlots_;
   // The number of elements in rsrvSlots_.
   int16_t rsrvSlotCnt_;

--- a/include/opt-sched/Scheduler/gen_sched.h
+++ b/include/opt-sched/Scheduler/gen_sched.h
@@ -179,12 +179,14 @@ protected:
   int16_t *avlblSlotsInCrntCycle_;
   // pointer to a device array used to store avlblSlotsInCrntCycle_ for
   // each thread by parallel ACO
+  // Indexed by GLOBALTID * num issue types + issue type
   int16_t *dev_avlblSlotsInCrntCycle_;
 
   // The reserved scheduling slots.
   ReserveSlot *rsrvSlots_;
   // pointer to a device array used to store rsrvSlots_ for
   // each thread by parallel ACO
+  // Indexed by GLOBALTID * issue rate + issue slot number
   ReserveSlot *dev_rsrvSlots_;
   // The number of elements in rsrvSlots_.
   int16_t rsrvSlotCnt_;

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -488,10 +488,10 @@ public:
   void SetMustBeInBBExit(bool val);
 
   // Add a register definition to this instruction node.
-  __host__ __device__
+  __host__
   void AddDef(Register *reg);
   // Add a register usage to this instruction node.
-  __host__ __device__
+  __host__
   void AddUse(Register *reg);
   // Returns whether this instruction defines the specified register.
   __host__ __device__
@@ -502,11 +502,11 @@ public:
   
   // Retrieves the list of registers defined by this node. The array is put
   // into defs and the number of elements is returned.
-  __host__ __device__
+  __host__
   int16_t GetDefs(RegIndxTuple *&defs);
   // Retrieves the list of registers used by this node. The array is put
   // into uses and the number of elements is returned.
-  __host__ __device__
+  __host__
   int16_t GetUses(RegIndxTuple *&uses);
 
   __host__ __device__
@@ -518,7 +518,7 @@ public:
   __host__ __device__
   int16_t GetAdjustedUseCnt() { return adjustedUseCnt_; }
   // Computer the adjusted use count. Update "adjustedUseCnt_".
-  __host__ __device__
+  __host__
   void ComputeAdjustedUseCnt(SchedInstruction *inst);
 
   __host__ __device__
@@ -566,6 +566,10 @@ public:
 
   // This instruction's index in the ltncyPerPrdcsr_ array in the DDG.
   int ddgPredecessorIndex;
+
+  // This instruction's indices for the uses_ and defs_ arrays in the DDG.
+  int ddgUseIndex;
+  int ddgDefIndex;
 
   __device__
   int GetScsrCnt_();
@@ -705,11 +709,11 @@ protected:
   // Pointer to RegFiles
   RegisterFile *RegFiles_;
   // The registers defined by this instruction node.
-  RegIndxTuple defs_[MAX_DEFS_PER_INSTR];
+  RegIndxTuple *defs_;
   // The number of elements in defs.
   int16_t defCnt_;
   // The registers used by this instruction node.
-  RegIndxTuple uses_[MAX_USES_PER_INSTR];
+  RegIndxTuple *uses_;
   // The number of elements in uses.
   int16_t useCnt_;
   // The number of uses minus live-out registers. Live-out registers are uses
@@ -761,7 +765,7 @@ protected:
   __host__
   void SetScsrNums_();
   // Computer the adjusted use count. Update "adjustedUseCnt_".
-  __host__ __device__
+  __host__
   void ComputeAdjustedUseCnt_();
 };
 

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -55,6 +55,8 @@ public:
   // Destroys the region. Must be overriden by child classes.
   virtual ~SchedRegion() {}
 
+  void SetNumThreads(int numThreads_);
+
   // Returns the dependence graph of this region.
   inline DataDepGraph *GetDepGraph() { return dataDepGraph_; }
   //for updating DDG pointer to DDG created on device
@@ -186,6 +188,8 @@ protected:
   MachineModel *machMdl_;
   // Pointer to machMdl_ on the device
   MachineModel *dev_machMdl_;
+
+  int numThreads_;
 
   // The schedule currently used by the enumerator
   InstSchedule *enumCrntSched_;

--- a/lib/Scheduler/aco.hip.cpp
+++ b/lib/Scheduler/aco.hip.cpp
@@ -1861,17 +1861,9 @@ void ACOScheduler::AllocDevArraysForParallelACO() {
   // Alloc dev array for avlblSlotsInCrntCycle_
   memSize = sizeof(int16_t) * issuTypeCnt_ * numThreads_;
   gpuErrchk(hipMalloc(&dev_avlblSlotsInCrntCycle_, memSize));
-  // Alloc dev arrays of avlblSlotsInCrntCycle_ for each thread
-  // memSize = sizeof(int16_t) * issuTypeCnt_;
-  // for (int i = 0; i < numThreads_; i++) {
-  //   gpuErrchk(hipMalloc(&dev_avlblSlotsInCrntCycle_[i], memSize));
-  // }
   // Alloc dev arrays for rsrvSlots_
   memSize = sizeof(ReserveSlot) * issuRate_ * numThreads_;
   gpuErrchk(hipMalloc(&dev_rsrvSlots_, memSize));
-  // for (int i = 0; i < numThreads_; i++) {
-  //   gpuErrchk(hipMalloc(&dev_rsrvSlots_[i], memSize));
-  // }
   memSize = sizeof(int16_t) * numThreads_;
   gpuErrchk(hipMalloc(&dev_rsrvSlotCnt_, memSize));
 }
@@ -1925,11 +1917,6 @@ void ACOScheduler::CopyPointersToDevice(ACOScheduler *dev_ACOSchedulr) {
   gpuErrchk(hipMalloc(&dev_ACOSchedulr->dev_kHelper, memSize));
   gpuErrchk(hipMemcpy(dev_ACOSchedulr->dev_kHelper, kHelper, memSize,
 		       hipMemcpyHostToDevice));
-  // make sure hipMallocManaged memory is copied to device before kernel start
-  //memSize = sizeof(int16_t *) * numThreads_;
-  //gpuErrchk(hipMemPrefetchAsync(dev_avlblSlotsInCrntCycle_, memSize, 0));
-  //memSize = sizeof(ReserveSlot *) * numThreads_;
-  //gpuErrchk(hipMemPrefetchAsync(dev_rsrvSlots_, memSize, 0));
 }
 
 void ACOScheduler::FreeDevicePointers() {
@@ -1940,10 +1927,6 @@ void ACOScheduler::FreeDevicePointers() {
   hipFree(dev_isCrntCycleBlkd_);
   hipFree(slotsPerTypePerCycle_);
   hipFree(instCntPerIssuType_);
-  for (int i = 0; i < numThreads_; i++){
-    //hipFree(dev_avlblSlotsInCrntCycle_[i]);
-    //hipFree(dev_rsrvSlots_[i]);
-  }
   hipFree(dev_MaxScoringInst);
   readyLs->FreeDevicePointers();
   hipFree(dev_avlblSlotsInCrntCycle_);

--- a/lib/Scheduler/aco.hip.cpp
+++ b/lib/Scheduler/aco.hip.cpp
@@ -1857,13 +1857,13 @@ void ACOScheduler::AllocDevArraysForParallelACO() {
   memSize = sizeof(InstCount) * numThreads_;
   gpuErrchk(hipMalloc(&dev_MaxScoringInst, memSize));
   // Alloc dev array for avlblSlotsInCrntCycle_
-  memSize = sizeof(int16_t *) * numThreads_;
-  gpuErrchk(hipMallocManaged(&dev_avlblSlotsInCrntCycle_, memSize));
+  memSize = sizeof(int16_t) * issuTypeCnt_ * numThreads_;
+  gpuErrchk(hipMalloc(&dev_avlblSlotsInCrntCycle_, memSize));
   // Alloc dev arrays of avlblSlotsInCrntCycle_ for each thread
-  memSize = sizeof(int16_t) * issuTypeCnt_;
-  for (int i = 0; i < numThreads_; i++) {
-    gpuErrchk(hipMalloc(&dev_avlblSlotsInCrntCycle_[i], memSize));
-  }
+  // memSize = sizeof(int16_t) * issuTypeCnt_;
+  // for (int i = 0; i < numThreads_; i++) {
+  //   gpuErrchk(hipMalloc(&dev_avlblSlotsInCrntCycle_[i], memSize));
+  // }
   // Alloc dev arrays for rsrvSlots_
   memSize = sizeof(ReserveSlot *) * numThreads_;
   gpuErrchk(hipMallocManaged(&dev_rsrvSlots_, memSize));
@@ -1925,8 +1925,8 @@ void ACOScheduler::CopyPointersToDevice(ACOScheduler *dev_ACOSchedulr) {
   gpuErrchk(hipMemcpy(dev_ACOSchedulr->dev_kHelper, kHelper, memSize,
 		       hipMemcpyHostToDevice));
   // make sure hipMallocManaged memory is copied to device before kernel start
-  memSize = sizeof(int16_t *) * numThreads_;
-  gpuErrchk(hipMemPrefetchAsync(dev_avlblSlotsInCrntCycle_, memSize, 0));
+  //memSize = sizeof(int16_t *) * numThreads_;
+  //gpuErrchk(hipMemPrefetchAsync(dev_avlblSlotsInCrntCycle_, memSize, 0));
   memSize = sizeof(ReserveSlot *) * numThreads_;
   gpuErrchk(hipMemPrefetchAsync(dev_rsrvSlots_, memSize, 0));
 }
@@ -1940,7 +1940,7 @@ void ACOScheduler::FreeDevicePointers() {
   hipFree(slotsPerTypePerCycle_);
   hipFree(instCntPerIssuType_);
   for (int i = 0; i < numThreads_; i++){
-    hipFree(dev_avlblSlotsInCrntCycle_[i]);
+    //hipFree(dev_avlblSlotsInCrntCycle_[i]);
     hipFree(dev_rsrvSlots_[i]);
   }
   hipFree(dev_MaxScoringInst);

--- a/lib/Scheduler/aco.hip.cpp
+++ b/lib/Scheduler/aco.hip.cpp
@@ -1865,12 +1865,11 @@ void ACOScheduler::AllocDevArraysForParallelACO() {
   //   gpuErrchk(hipMalloc(&dev_avlblSlotsInCrntCycle_[i], memSize));
   // }
   // Alloc dev arrays for rsrvSlots_
-  memSize = sizeof(ReserveSlot *) * numThreads_;
-  gpuErrchk(hipMallocManaged(&dev_rsrvSlots_, memSize));
-  memSize = sizeof(ReserveSlot) * issuRate_;
-  for (int i = 0; i < numThreads_; i++) {
-    gpuErrchk(hipMalloc(&dev_rsrvSlots_[i], memSize));
-  }
+  memSize = sizeof(ReserveSlot) * issuRate_ * numThreads_;
+  gpuErrchk(hipMalloc(&dev_rsrvSlots_, memSize));
+  // for (int i = 0; i < numThreads_; i++) {
+  //   gpuErrchk(hipMalloc(&dev_rsrvSlots_[i], memSize));
+  // }
   memSize = sizeof(int16_t) * numThreads_;
   gpuErrchk(hipMalloc(&dev_rsrvSlotCnt_, memSize));
 }
@@ -1927,8 +1926,8 @@ void ACOScheduler::CopyPointersToDevice(ACOScheduler *dev_ACOSchedulr) {
   // make sure hipMallocManaged memory is copied to device before kernel start
   //memSize = sizeof(int16_t *) * numThreads_;
   //gpuErrchk(hipMemPrefetchAsync(dev_avlblSlotsInCrntCycle_, memSize, 0));
-  memSize = sizeof(ReserveSlot *) * numThreads_;
-  gpuErrchk(hipMemPrefetchAsync(dev_rsrvSlots_, memSize, 0));
+  //memSize = sizeof(ReserveSlot *) * numThreads_;
+  //gpuErrchk(hipMemPrefetchAsync(dev_rsrvSlots_, memSize, 0));
 }
 
 void ACOScheduler::FreeDevicePointers() {
@@ -1941,7 +1940,7 @@ void ACOScheduler::FreeDevicePointers() {
   hipFree(instCntPerIssuType_);
   for (int i = 0; i < numThreads_; i++){
     //hipFree(dev_avlblSlotsInCrntCycle_[i]);
-    hipFree(dev_rsrvSlots_[i]);
+    //hipFree(dev_rsrvSlots_[i]);
   }
   hipFree(dev_MaxScoringInst);
   readyLs->FreeDevicePointers();

--- a/lib/Scheduler/aco.hip.cpp
+++ b/lib/Scheduler/aco.hip.cpp
@@ -301,11 +301,13 @@ InstCount ACOScheduler::SelectInstruction(SchedInstruction *lastInst, InstCount 
 
         // check if any reg types used by the instructions are above the physical register limit
         SchedInstruction *tempInst = dataDepGraph_->GetInstByIndx(*dev_readyLs->getInstIdAtIndex(I));
+        // TODO(bruce): convert to dev uses
         RegIndxTuple *uses;
         Register *use;
-        uint16_t usesCount = tempInst->GetUses(uses);
+        uint16_t usesCount = tempInst->GetUseCnt();
+        int useStart = tempInst->ddgUseIndex;
         for (uint16_t i = 0; i < usesCount; i++) {
-          use = dataDepGraph_->getRegByTuple(&uses[i]);
+          use = dataDepGraph_->getRegByTuple(dataDepGraph_->getUseByIndex(useStart + i));
           int16_t regType = use->GetType();
           if ( ((BBWithSpill *)rgn)->IsRPHigh(regType) ) {
             RPIsHigh = true;

--- a/lib/Scheduler/aco.hip.cpp
+++ b/lib/Scheduler/aco.hip.cpp
@@ -70,6 +70,10 @@ ACOScheduler::ACOScheduler(DataDepGraph *dataDepGraph,
   numThreads_ = numBlocks_ * NUMTHREADSPERBLOCK;
   if(!DEV_ACO || count_ < REGION_MIN_SIZE)
     numThreads_ = schedIni.GetInt("HOST_ANTS");
+  else {
+    dev_rgn_->SetNumThreads(numThreads_);
+    dev_DDG_->SetNumThreads(numThreads_);
+  }
 
   use_fixed_bias = schedIni.GetBool("ACO_USE_FIXED_BIAS");
   use_tournament = schedIni.GetBool("ACO_TOURNAMENT");
@@ -538,6 +542,7 @@ InstSchedule *ACOScheduler::FindOneSchedule(InstCount RPTarget,
   SchedInstruction *lastInst = NULL;
   ACOReadyListEntry LastInstInfo;
   InstSchedule *schedule = dev_schedule;
+  schedule->SetNumThreads(numThreads_);
   bool IsSecondPass = dev_rgn_->IsSecondPass();
   dev_readyLs->clearReadyList();
   ScRelMax = dev_rgn_->GetHeuristicCost();

--- a/lib/Scheduler/bb_spill.hip.cpp
+++ b/lib/Scheduler/bb_spill.hip.cpp
@@ -573,18 +573,20 @@ void BBWithSpill::UpdateSpillInfoForSchdul_(SchedInstruction *inst,
   InstCount newSpillCost;
   InstCount perpValueForSlil;
 
-  defCnt = inst->GetDefs(defs);
-  useCnt = inst->GetUses(uses);
-
 #ifdef __HIP_DEVICE_COMPILE__ // Device Version of function
 #ifdef IS_DEBUG_REG_PRESSURE
   Logger::Info("Updating reg pressure after scheduling Inst %d",
                inst->GetNum());
 #endif
 
+  defCnt = inst->GetDefCnt();
+  useCnt = inst->GetUseCnt();
+
   // Update Live regs after uses
+  // TODO(bruce): convert to dev uses
+  int useStart = inst->ddgUseIndex;
   for (int i = 0; i < useCnt; i++) {
-    use = dataDepGraph_->getRegByTuple(&uses[i]);
+    use = dataDepGraph_->getRegByTuple(dataDepGraph_->getUseByIndex(useStart + i));
     regType = use->GetType();
     regNum = use->GetNum();
     physRegNum = use->GetPhysicalNumber();
@@ -622,8 +624,10 @@ void BBWithSpill::UpdateSpillInfoForSchdul_(SchedInstruction *inst,
   }
 
   // Update Live regs after defs
+  // TODO(bruce): convert to dev defs
+  int defStart = inst->ddgDefIndex;
   for (int i = 0; i < defCnt; i++) {
-    def = dataDepGraph_->getRegByTuple(&defs[i]);
+    def = dataDepGraph_->getRegByTuple(dataDepGraph_->getDefByIndex(defStart + i));
     regType = def->GetType();
     regNum = def->GetNum();
     physRegNum = def->GetPhysicalNumber();
@@ -724,6 +728,9 @@ void BBWithSpill::UpdateSpillInfoForSchdul_(SchedInstruction *inst,
   Logger::Info("Updating reg pressure after scheduling Inst %d",
                inst->GetNum());
 #endif
+
+  defCnt = inst->GetDefs(defs);
+  useCnt = inst->GetUses(uses);
 
   // Update Live regs after uses
   for (int i = 0; i < useCnt; i++) {

--- a/lib/Scheduler/bb_spill.hip.cpp
+++ b/lib/Scheduler/bb_spill.hip.cpp
@@ -1633,28 +1633,13 @@ void BBWithSpill::AllocDevArraysForParallelACO(int numThreads) {
   hipMallocManaged(&dev_livePhysRegs_, memSize);
   memSize = sizeof(InstCount) * regTypeCnt_ * numThreads;
   hipMalloc(&dev_peakRegPressures_, memSize);
-  //memSize = sizeof(InstCount) * regTypeCnt_ * numThreads;
-  //hipMalloc(&temp, memSize);
-  //for (int i = 0; i < regTypeCnt_; i++)
-  //  dev_peakRegPressures_[i] = &temp[i * numThreads];
   memSize = sizeof(unsigned) * regTypeCnt_ * numThreads;
   hipMalloc(&dev_regPressures_, memSize);
-  // hipMalloc(&u_temp, memSize);
-  // for (int i = 0; i < regTypeCnt_; i++)
-  //   dev_regPressures_[i] = &u_temp[i * numThreads];
   memSize = sizeof(InstCount) * dataDepGraph_->GetInstCnt() * numThreads;
   hipMalloc(&dev_spillCosts_, memSize);
-  // memSize = sizeof(InstCount) * dataDepGraph_->GetInstCnt() * numThreads;
-  // hipMalloc(&temp, memSize);
-  // for (int i = 0; i < dataDepGraph_->GetInstCnt(); i++)
-  //   dev_spillCosts_[i] = &temp[i * numThreads];
   if (needsSLIL()) {
     memSize = sizeof(int) * regTypeCnt_ * numThreads;
     hipMalloc(&dev_sumOfLiveIntervalLengths_, memSize);
-    // memSize = sizeof(int) * regTypeCnt_ * numThreads;
-    // hipMalloc(&temp, memSize);
-    // for (int i = 0; i < regTypeCnt_; i++)
-    //   dev_sumOfLiveIntervalLengths_[i] = &temp[i * numThreads];
   }
 }
 
@@ -1773,16 +1758,6 @@ void BBWithSpill::CopyPointersToDevice(SchedRegion* dev_rgn, int numThreads) {
   memSize = sizeof(WeightedBitVector *) * regTypeCnt_;
   gpuErrchk(hipMemPrefetchAsync(dev_liveRegs_, memSize, 0));
   gpuErrchk(hipMemPrefetchAsync(dev_livePhysRegs_, memSize, 0));
-  //memSize = sizeof(InstCount *) * regTypeCnt_;
-  //gpuErrchk(hipMemPrefetchAsync(dev_peakRegPressures_, memSize, 0));
-  memSize = sizeof(unsigned *) * regTypeCnt_;
-  //gpuErrchk(hipMemPrefetchAsync(dev_regPressures_, memSize, 0));
-  memSize = sizeof(InstCount *) * dataDepGraph_->GetInstCnt();
-  //gpuErrchk(hipMemPrefetchAsync(dev_spillCosts_, memSize, 0));
-  if (needsSLIL()) {
-    memSize = sizeof(int *) * regTypeCnt_;
-    //gpuErrchk(hipMemPrefetchAsync(dev_sumOfLiveIntervalLengths_, memSize, 0));
-  }
 }
 
 void BBWithSpill::FreeDevicePointers(int numThreads) {
@@ -1801,16 +1776,12 @@ void BBWithSpill::FreeDevicePointers(int numThreads) {
   if (needsSLIL()) {
     hipFree(dev_slilSpillCost_);
     hipFree(dev_dynamicSlilLowerBound_);
-    //hipFree(dev_sumOfLiveIntervalLengths_[0]);
     hipFree(dev_sumOfLiveIntervalLengths_);
   }
   hipFree(dev_schduldEntryInstCnt_);
   hipFree(dev_schduldExitInstCnt_);
   hipFree(dev_schduldInstCnt_);
-  //hipFree(dev_peakRegPressures_[0]);
   hipFree(dev_peakRegPressures_);
-  //hipFree(dev_regPressures_[0]);
   hipFree(dev_regPressures_);
-  //hipFree(dev_spillCosts_[0]);
   hipFree(dev_spillCosts_);
 }

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -229,11 +229,6 @@ DataDepGraph::DataDepGraph(MachineModel *machMdl, LATENCY_PRECISION ltncyPrcsn)
 #endif
 
   RegFiles = new RegisterFile[machMdl_->GetRegTypeCnt()];
-
-  Config &schedIni = SchedulerOptions::getInstance();
-  numThreads_ = numBlocks_ * NUMTHREADSPERBLOCK;
-  if(!DEV_ACO || count_ < REGION_MIN_SIZE)
-    numThreads_ = schedIni.GetInt("HOST_ANTS");
 }
 
 __host__
@@ -242,6 +237,10 @@ DataDepGraph::~DataDepGraph() {
     delete[] insts_;
   }
   delete[] instCntPerType_;
+}
+
+void DataDepGraph::SetNumThreads(int numThreads) {
+  numThreads_ = numThreads;
 }
 
 __host__
@@ -2793,6 +2792,11 @@ bool InstSchedule::operator==(InstSchedule &b) const {
       return false;
   }
   return true;
+}
+
+__host__ __device__
+void InstSchedule::SetNumThreads(int numThreads) {
+  numThreads_ = numThreads;
 }
 
 __host__ __device__

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -2994,11 +2994,11 @@ void InstSchedule::SetSpillCosts(InstCount spillCosts[]) {
 }
 
 __device__
-void InstSchedule::Dev_SetSpillCosts(InstCount **spillCosts) {
+void InstSchedule::Dev_SetSpillCosts(InstCount *spillCosts) {
   totSpillCost_ = 0;
   for (InstCount i = 0; i < totInstCnt_; i++) {
-    dev_spillCosts_[i] = spillCosts[i][GLOBALTID];
-    totSpillCost_ += spillCosts[i][GLOBALTID];
+    dev_spillCosts_[i] = spillCosts[GLOBALTID*totInstCnt_+i];
+    totSpillCost_ += spillCosts[GLOBALTID*totInstCnt_+i];
   }  
 }
 

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -3699,7 +3699,6 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   scsrs_ = new int[lngthScsrElmnts];
   latencies_ = new int[lngthScsrElmnts];
   predOrder_ = new int[lngthScsrElmnts];
-  // TODO(bruce): free
   uses_ = new RegIndxTuple[lengthUses];
   defs_ = new RegIndxTuple[lengthDefs];
   ltncyPerPrdcsr_ = new int[lengthLatencies];
@@ -3737,7 +3736,6 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
     numUses = insts_[i].GetUses(myUses);
     for (int j = 0; j < numUses; j++) {
       uses_[indexUseOffset++] = myUses[j]; 
-      // TODO(bruce): set SchedInstruction field accordingly
     }
 
     // Partition defs_ for each SchedInstruction.
@@ -3746,7 +3744,6 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
     numDefs = insts_[i].GetDefs(myDefs);
     for (int j = 0; j < numDefs; j++) {
       defs_[indexDefOffset++] = myDefs[j]; 
-      // TODO(bruce): set SchedInstruction field accordingly
     }
 
     // Partition ltncyPerPrdcsr_ for each SchedInstruction.

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -3688,13 +3688,11 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   int lengthLatencies = 0;
   int lengthUses = 0;
   int lengthDefs = 0;
-  // TODO(bruce): remove
-  RegIndxTuple *_defs, *_uses;
   for (InstCount i = 0; i < instCnt_; i++) {
     lngthScsrElmnts += insts_[i].GetScsrCnt();
     lengthLatencies += insts_[i].GetPrdcsrCnt();
-    lengthUses += insts_[i].GetUses(_uses);
-    lengthDefs += insts_[i].GetDefs(_defs);
+    lengthUses += insts_[i].GetUseCnt();
+    lengthDefs += insts_[i].GetDefCnt();
   }
 
   scsrs_ = new int[lngthScsrElmnts];
@@ -3784,8 +3782,8 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   gpuErrchk(hipMalloc(&(dev_DDG->defs_), memSize));
   gpuErrchk(hipMemcpy(dev_DDG->defs_, defs_, memSize, hipMemcpyHostToDevice));
 
-  delete uses_;
-  delete defs_;
+  delete[] uses_;
+  delete[] defs_;
 
   memSize = sizeof(int) * lengthLatencies;
   gpuErrchk(hipMalloc(&(dev_DDG->ltncyPerPrdcsr_), memSize));

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -2997,8 +2997,8 @@ __device__
 void InstSchedule::Dev_SetSpillCosts(InstCount *spillCosts) {
   totSpillCost_ = 0;
   for (InstCount i = 0; i < totInstCnt_; i++) {
-    dev_spillCosts_[i] = spillCosts[GLOBALTID*totInstCnt_+i];
-    totSpillCost_ += spillCosts[GLOBALTID*totInstCnt_+i];
+    dev_spillCosts_[i] = spillCosts[i*NUMTHREADS+GLOBALTID];
+    totSpillCost_ += spillCosts[i*NUMTHREADS+GLOBALTID];
   }  
 }
 
@@ -3019,7 +3019,7 @@ __device__
 void InstSchedule::Dev_SetPeakRegPressures(InstCount *peakRegPressures) {
   int regTypeCount = dev_machMdl_->GetRegTypeCnt();
   for (InstCount i = 0; i < regTypeCount; i++) {
-    dev_peakRegPressures_[i] = peakRegPressures[GLOBALTID*regTypeCount+i];
+    dev_peakRegPressures_[i] = peakRegPressures[i*NUMTHREADS+GLOBALTID];
   }
 }
 

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -13,6 +13,7 @@
 #include "opt-sched/Scheduler/stats.h"
 #include "opt-sched/Scheduler/dev_defines.h"
 #include "opt-sched/Scheduler/aco.h"
+#include "opt-sched/Scheduler/config.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include <hip/hip_runtime.h>
@@ -228,6 +229,11 @@ DataDepGraph::DataDepGraph(MachineModel *machMdl, LATENCY_PRECISION ltncyPrcsn)
 #endif
 
   RegFiles = new RegisterFile[machMdl_->GetRegTypeCnt()];
+
+  Config &schedIni = SchedulerOptions::getInstance();
+  numThreads_ = numBlocks_ * NUMTHREADSPERBLOCK;
+  if(!DEV_ACO || count_ < REGION_MIN_SIZE)
+    numThreads_ = schedIni.GetInt("HOST_ANTS");
 }
 
 __host__

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -3003,8 +3003,8 @@ __device__
 void InstSchedule::Dev_SetSpillCosts(InstCount *spillCosts) {
   totSpillCost_ = 0;
   for (InstCount i = 0; i < totInstCnt_; i++) {
-    dev_spillCosts_[i] = spillCosts[i*NUMTHREADS+GLOBALTID];
-    totSpillCost_ += spillCosts[i*NUMTHREADS+GLOBALTID];
+    dev_spillCosts_[i] = spillCosts[i*numThreads_+GLOBALTID];
+    totSpillCost_ += spillCosts[i*numThreads_+GLOBALTID];
   }  
 }
 
@@ -3025,7 +3025,7 @@ __device__
 void InstSchedule::Dev_SetPeakRegPressures(InstCount *peakRegPressures) {
   int regTypeCount = dev_machMdl_->GetRegTypeCnt();
   for (InstCount i = 0; i < regTypeCount; i++) {
-    dev_peakRegPressures_[i] = peakRegPressures[i*NUMTHREADS+GLOBALTID];
+    dev_peakRegPressures_[i] = peakRegPressures[i*numThreads_+GLOBALTID];
   }
 }
 

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -3016,9 +3016,10 @@ void InstSchedule::SetPeakRegPressures(InstCount peakRegPressures[]) {
 }
 
 __device__
-void InstSchedule::Dev_SetPeakRegPressures(InstCount **peakRegPressures) {
-  for (InstCount i = 0; i < dev_machMdl_->GetRegTypeCnt(); i++) {
-    dev_peakRegPressures_[i] = peakRegPressures[i][GLOBALTID];
+void InstSchedule::Dev_SetPeakRegPressures(InstCount *peakRegPressures) {
+  int regTypeCount = dev_machMdl_->GetRegTypeCnt();
+  for (InstCount i = 0; i < regTypeCount; i++) {
+    dev_peakRegPressures_[i] = peakRegPressures[GLOBALTID*regTypeCount+i];
   }
 }
 

--- a/lib/Scheduler/data_dep.hip.cpp
+++ b/lib/Scheduler/data_dep.hip.cpp
@@ -3780,9 +3780,6 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   gpuErrchk(hipMalloc(&(dev_DDG->defs_), memSize));
   gpuErrchk(hipMemcpy(dev_DDG->defs_, defs_, memSize, hipMemcpyHostToDevice));
 
-  delete[] uses_;
-  delete[] defs_;
-
   memSize = sizeof(int) * lengthLatencies;
   gpuErrchk(hipMalloc(&(dev_DDG->ltncyPerPrdcsr_), memSize));
   gpuErrchk(hipMemcpy(dev_DDG->ltncyPerPrdcsr_, ltncyPerPrdcsr_, memSize, hipMemcpyHostToDevice));
@@ -3791,6 +3788,14 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   gpuErrchk(hipMemPrefetchAsync(dev_insts, memSize, 0));
   memSize = sizeof(RegisterFile) * machMdl_->GetRegTypeCnt();
   gpuErrchk(hipMemPrefetchAsync(dev_regFiles, memSize, 0));
+
+  // Clean up temporary host arrays
+  delete[] scsrs_;
+  delete[] latencies_;
+  delete[] predOrder_;
+  delete[] ltncyPerPrdcsr_;
+  delete[] uses_;
+  delete[] defs_;
 }
 
 void DataDepGraph::FreeDevicePointers(int numThreads) {

--- a/lib/Scheduler/gen_sched.hip.cpp
+++ b/lib/Scheduler/gen_sched.hip.cpp
@@ -56,7 +56,6 @@ __host__ __device__
 void ConstrainedScheduler::ResetRsrvSlots_() {
   assert(includesUnpipelined_);
 #ifdef __HIP_DEVICE_COMPILE__
-  //assert(dev_rsrvSlots_[GLOBALTID*issuRate] != NULL);
 
   for (int i = 0; i < issuRate_; i++) {
     dev_rsrvSlots_[GLOBALTID*issuRate_+i].strtCycle = INVALID_VALUE;

--- a/lib/Scheduler/gen_sched.hip.cpp
+++ b/lib/Scheduler/gen_sched.hip.cpp
@@ -439,7 +439,6 @@ bool ConstrainedScheduler::ChkInstLglty_(SchedInstruction *inst) const {
   if (inst->BlocksCycle() && dev_crntSlotNum_[GLOBALTID] != 0)
     return false;
   // Logger::Info("Does not block cycle");
-  // TODO(bruce): make sure nothing is broken here
   if (includesUnpipelined_ &&
       dev_rsrvSlots_[GLOBALTID*issuRate_+dev_crntSlotNum_[GLOBALTID]].strtCycle != INVALID_VALUE &&
       dev_crntCycleNum_[GLOBALTID] <= 

--- a/lib/Scheduler/gen_sched.hip.cpp
+++ b/lib/Scheduler/gen_sched.hip.cpp
@@ -56,11 +56,11 @@ __host__ __device__
 void ConstrainedScheduler::ResetRsrvSlots_() {
   assert(includesUnpipelined_);
 #ifdef __HIP_DEVICE_COMPILE__
-  assert(dev_rsrvSlots_[GLOBALTID] != NULL);
+  //assert(dev_rsrvSlots_[GLOBALTID*issuRate] != NULL);
 
   for (int i = 0; i < issuRate_; i++) {
-    dev_rsrvSlots_[GLOBALTID][i].strtCycle = INVALID_VALUE;
-    dev_rsrvSlots_[GLOBALTID][i].endCycle = INVALID_VALUE;
+    dev_rsrvSlots_[GLOBALTID*issuRate_+i].strtCycle = INVALID_VALUE;
+    dev_rsrvSlots_[GLOBALTID*issuRate_+i].endCycle = INVALID_VALUE;
   }
 
   dev_rsrvSlotCnt_[GLOBALTID] = 0;
@@ -439,10 +439,11 @@ bool ConstrainedScheduler::ChkInstLglty_(SchedInstruction *inst) const {
   if (inst->BlocksCycle() && dev_crntSlotNum_[GLOBALTID] != 0)
     return false;
   // Logger::Info("Does not block cycle");
-  if (includesUnpipelined_ && dev_rsrvSlots_[GLOBALTID] &&
-      dev_rsrvSlots_[GLOBALTID][dev_crntSlotNum_[GLOBALTID]].strtCycle != INVALID_VALUE &&
+  // TODO(bruce): make sure nothing is broken here
+  if (includesUnpipelined_ &&
+      dev_rsrvSlots_[GLOBALTID*issuRate_+dev_crntSlotNum_[GLOBALTID]].strtCycle != INVALID_VALUE &&
       dev_crntCycleNum_[GLOBALTID] <= 
-      dev_rsrvSlots_[GLOBALTID][dev_crntSlotNum_[GLOBALTID]].endCycle) {
+      dev_rsrvSlots_[GLOBALTID*issuRate_+dev_crntSlotNum_[GLOBALTID]].endCycle) {
     return false;
   }
 

--- a/lib/Scheduler/gen_sched.hip.cpp
+++ b/lib/Scheduler/gen_sched.hip.cpp
@@ -323,7 +323,7 @@ void ConstrainedScheduler::InitNewCycle_() {
   assert(dev_crntSlotNum_[GLOBALTID] == 0 && 
          dev_crntRealSlotNum_[GLOBALTID] == 0);
   for (int i = 0; i < issuTypeCnt_; i++) {
-    dev_avlblSlotsInCrntCycle_[GLOBALTID][i] = slotsPerTypePerCycle_[i];
+    dev_avlblSlotsInCrntCycle_[GLOBALTID*issuTypeCnt_+i] = slotsPerTypePerCycle_[i];
   }
   dev_isCrntCycleBlkd_[GLOBALTID] = false;
 #else
@@ -448,9 +448,9 @@ bool ConstrainedScheduler::ChkInstLglty_(SchedInstruction *inst) const {
 
   IssueType issuType = inst->GetIssueType();
   assert(issuType < issuTypeCnt_);
-  assert(dev_avlblSlotsInCrntCycle_[GLOBALTID][issuType] >= 0);
+  assert(dev_avlblSlotsInCrntCycle_[GLOBALTID*issuTypeCnt_+issuType] >= 0);
   // Logger::Info("avlblSlots = %d", avlblSlotsInCrntCycle_[issuType]);
-  return (dev_avlblSlotsInCrntCycle_[GLOBALTID][issuType] > 0);
+  return (dev_avlblSlotsInCrntCycle_[GLOBALTID*issuTypeCnt_+issuType] > 0);
 #else
   // Account for instructions that block the whole cycle.
   if (isCrntCycleBlkd_)
@@ -489,8 +489,8 @@ void ConstrainedScheduler::UpdtSlotAvlblty_(SchedInstruction *inst) {
   IssueType issuType = inst->GetIssueType();
   assert(issuType < issuTypeCnt_);
 #ifdef __HIP_DEVICE_COMPILE__
-  assert(dev_avlblSlotsInCrntCycle_[GLOBALTID][issuType] > 0);
-  dev_avlblSlotsInCrntCycle_[GLOBALTID][issuType]--;
+  assert(dev_avlblSlotsInCrntCycle_[GLOBALTID*issuTypeCnt_+issuType] > 0);
+  dev_avlblSlotsInCrntCycle_[GLOBALTID*issuTypeCnt_+issuType]--;
 #else
   assert(avlblSlotsInCrntCycle_[issuType] > 0);
   avlblSlotsInCrntCycle_[issuType]--;

--- a/lib/Scheduler/sched_basic_data.hip.cpp
+++ b/lib/Scheduler/sched_basic_data.hip.cpp
@@ -48,6 +48,11 @@ SchedInstruction::SchedInstruction(InstCount num, const char *name,
 
   instType_ = instType;
 
+  #ifndef __HIP_DEVICE_COMPILE__
+    defs_ = new RegIndxTuple[MAX_DEFS_PER_INSTR];
+    uses_ = new RegIndxTuple[MAX_USES_PER_INSTR]; 
+  #endif
+
   frwrdLwrBound_ = INVALID_VALUE;
   bkwrdLwrBound_ = INVALID_VALUE;
   abslutFrwrdLwrBound_ = INVALID_VALUE;
@@ -102,6 +107,8 @@ SchedInstruction::~SchedInstruction() {
   if (memAllocd_)
     DeAllocMem_();
 
+  delete defs_;
+  delete uses_;
   delete crntRange_;
 }
 
@@ -304,7 +311,7 @@ bool SchedInstruction::ApplyPreFxng(LinkedList<SchedInstruction> *tightndLst,
   return crntRange_->Fix(preFxdCycle_, tightndLst, fxdLst);
 }
 
-__host__ __device__
+__host__
 void SchedInstruction::AddDef(Register *reg) {
   if (defCnt_ >= MAX_DEFS_PER_INSTR) {
 #ifndef __HIP_DEVICE_COMPILE__
@@ -325,7 +332,7 @@ void SchedInstruction::AddDef(Register *reg) {
   defCnt_++;
 }
 
-__host__ __device__
+__host__
 void SchedInstruction::AddUse(Register *reg) {
   if (useCnt_ >= MAX_USES_PER_INSTR) {
 #ifndef __HIP_DEVICE_COMPILE__
@@ -372,15 +379,15 @@ bool SchedInstruction::FindUse(Register *reg) const {
   return false;
 }
 
-__host__ __device__
+__host__
 int16_t SchedInstruction::GetDefs(RegIndxTuple *&defs) {
-  defs = (RegIndxTuple *)&defs_;
+  defs = defs_;
   return defCnt_;
 }
 
-__host__ __device__
+__host__
 int16_t SchedInstruction::GetUses(RegIndxTuple *&uses) {
-  uses = (RegIndxTuple *)&uses_;
+  uses = uses_;
   return useCnt_;
 }
 
@@ -883,7 +890,7 @@ bool SchedInstruction::ProbeScsrsCrntLwrBounds(InstCount cycle) {
   return false;
 }
 
-__host__ __device__
+__host__
 void SchedInstruction::ComputeAdjustedUseCnt_() {
   RegIndxTuple *uses;
   int useCnt = GetUses(uses);
@@ -971,7 +978,6 @@ else
 }
 
 
-// TODO(bruce): is this actually run on the device?
 __host__ __device__
 void SchedInstruction::InitializeNode_(InstCount instNum, 
 		         const char *const instName,
@@ -1027,6 +1033,11 @@ void SchedInstruction::InitializeNode_(InstCount instNum,
   blksCycle_ = model->BlocksCycle(instType);
   pipelined_ = model->IsPipelined(instType);
 
+  #ifndef __HIP_DEVICE_COMPILE__
+    defs_ = new RegIndxTuple[MAX_DEFS_PER_INSTR];
+    uses_ = new RegIndxTuple[MAX_USES_PER_INSTR]; 
+  #endif
+
   defCnt_ = 0;
   useCnt_ = 0;
 
@@ -1062,6 +1073,9 @@ void SchedInstruction::CopyPointersToDevice(SchedInstruction *dev_inst,
 
   // Index of this instruction's partition in DDG's ltncyPerPrdcsr_.
   dev_inst->ddgPredecessorIndex = ddgPredecessorIndex;
+
+  dev_inst->ddgUseIndex = ddgUseIndex;
+  dev_inst->ddgDefIndex = ddgDefIndex;
 
   // Make sure instruction knows whether it's a leaf on device for legality checking.
   dev_inst->SetDevIsLeaf(scsrCnt_ == 0);

--- a/lib/Scheduler/sched_basic_data.hip.cpp
+++ b/lib/Scheduler/sched_basic_data.hip.cpp
@@ -107,8 +107,8 @@ SchedInstruction::~SchedInstruction() {
   if (memAllocd_)
     DeAllocMem_();
 
-  delete defs_;
-  delete uses_;
+  delete[] uses_;
+  delete[] defs_;
   delete crntRange_;
 }
 

--- a/lib/Scheduler/sched_region.hip.cpp
+++ b/lib/Scheduler/sched_region.hip.cpp
@@ -122,6 +122,10 @@ void SchedRegion::UseFileBounds_() {
   schedLwrBound_ = fileLwrBound;
 }
 
+void SchedRegion::SetNumThreads(int numThreads) {
+  numThreads_ = numThreads;
+}
+
 InstSchedule *SchedRegion::AllocNewSched_() {
   InstSchedule *newSched =
       new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);


### PR DESCRIPTION
Summary of changes:

- Batches uses_ and defs_ for use on the device to replace the static 16K allocation per SchedInstruction.
- Several 2D arrays containing per-thread data are now 1D arrays where different sections are accessed by global thread ID.

 

